### PR TITLE
Proposal for $map

### DIFF
--- a/specification.yml
+++ b/specification.yml
@@ -184,3 +184,58 @@ context:  {a: 3, b: 2}
 template: {$eval: '"" + (a + b)'}
 result:   '5'
 ################################################################################
+---
+section:  $map
+---
+title:    simple map
+context:  {a: 1}
+template:
+  $map: [2, 4, 6]
+  each(x): {$eval: 'x + a'}
+result:   [3, 5, 7]
+---
+title:    complex identifier
+context:  {a: 1}
+template:
+  $map: [2, 4, 6]
+  each(my_identifier97): {$eval: 'my_identifier97 + a'}
+result:   [3, 5, 7]
+---
+title:    must wrap expressions with $eval
+context:  {a: 1}
+template:
+  $map: [2, 4, 6]
+  each(my_identifier97): 'my_identifier97 + a'
+result:   ['my_identifier97 + a', 'my_identifier97 + a', 'my_identifier97 + a']
+---
+title:    can take from objects
+context:  {a: 1}
+template:
+  $map: [{k: 1}, {k: 2}, {k: 3}]
+  each(y): {$eval: 'y.k'}
+result:   [1, 2, 3]
+---
+title:    can make objects too
+context:  {a: 1}
+template:
+  $map: [{k: 1}, {k: 2}, {k: 3}]
+  each(y):
+    k: {$eval: 'y.k + 1'}
+    v: 'before=${y.k}'
+result:
+  - k: 2
+    v: 'before=1'
+  - k: 3
+    v: 'before=2'
+  - k: 4
+    v: 'before=3'
+ ---
+title:    respects delete-marker from $if
+context:  {a: 1}
+template:
+  $map: [{k: 1}, {k: 2}, {k: 3}]
+  each(y):
+    $if: 'y.k != 2'
+    then: {$eval: 'y.k'} 
+result: [1, 3]
+################################################################################

--- a/specification.yml
+++ b/specification.yml
@@ -201,7 +201,10 @@ template:
   each(x):
     asText: 'Count ${x + a}'
     integer: {$eval: 'x + a'}
-result:   [3, 5, 7]
+result:
+ - {asText: '2', integer: 3}
+ - {asText: '4', integer: 5}
+ - {asText: '6', integer: 7}
 ---
 title:    complex identifier
 context:  {a: 1}

--- a/specification.yml
+++ b/specification.yml
@@ -238,4 +238,11 @@ template:
     $if: 'y.k != 2'
     then: {$eval: 'y.k'} 
 result: [1, 3]
+---
+title:    $map requires an array
+context:  {}
+template:
+  $map: {a: 1, b: 2, c: 3}
+  each(y): {$eval: 'y.k'}
+error: true # can't do map on non-arrays
 ################################################################################

--- a/specification.yml
+++ b/specification.yml
@@ -194,6 +194,15 @@ template:
   each(x): {$eval: 'x + a'}
 result:   [3, 5, 7]
 ---
+title:    map to objects
+context:  {a: 1}
+template:
+  $map: [2, 4, 6]
+  each(x):
+    asText: 'Count ${x + a}'
+    integer: {$eval: 'x + a'}
+result:   [3, 5, 7]
+---
 title:    complex identifier
 context:  {a: 1}
 template:


### PR DESCRIPTION
I'm definitely open to other ideas...
Most the ones I had was something like:
```js
{
  $for: 'x' # specify variable
  in: [1,2,3]
  each: {$eval: 'x + 1'}
}
```
But it feels long an hard to see that `x` is the variable that gets declared in the context for the evaluation of the json-e expression given in `each`.

I like using `each(x)` because it's easy to read that each entry in the array will have the name `x` in the subexpression...

Thoughts, please? Other ideas are welcome too :)