### PR TITLE
in operator, exponentiation operator support and parseObject bug fix

### DIFF
--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -109,7 +109,7 @@ let parseString = (str) => {
   return str.replace('\"', '"').slice(1, -1);
 };
 
-let tetsComparisonOperands = (operator, left, right) => {
+let testComparisonOperands = (operator, left, right) => {
 
   if (operator === '==' || operator === '!=') {
     return null;
@@ -265,7 +265,7 @@ infixRules['>='] = infixRules['<'] =  infixRules['>']
   =  (left, token, ctx) => {
     let operator = token.kind;
     let right = ctx.parse(operator);
-    tetsComparisonOperands(operator, left, right);
+    testComparisonOperands(operator, left, right);
     switch (operator) {
       case '>=': return left >= right;
       case '<=': return left <= right;

--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -213,7 +213,11 @@ prefixRules['false'] = (token, ctx) => {
 infixRules['+'] = infixRules['-'] = infixRules['*'] = infixRules['/'] = infixRules['**']
   = (left, token, ctx) => {
     testMathOperand(token.value, left);
-    let right = ctx.parse(token.value);
+    let operator = token.value;
+    if (operator === '**') {
+      operator = '**-right-associative';
+    }
+    let right = ctx.parse(operator);
     testMathOperand(token.value, right);
     if (typeof left !== typeof right) {
       throw new InterpreterError(`TypeError: ${typeof left} ${token.value} ${typeof right}`);
@@ -321,6 +325,7 @@ module.exports = new PrattParser({
   	['>=', '<=', '<', '>'],
     ['+', '-'],
     ['*', '/'],
+    ['**-right-associative'],
     ['**'],
     ['[', '.'],
     ['('],

--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -33,11 +33,11 @@ let parseObject = (ctx) => {
   if (!ctx.attempt('}')) {
     do {
       let k = ctx.require('identifier', 'string');
-      ctx.require(':');
-      let v = ctx.parse();
       if (k.kind === 'string') {
         k.value = parseString(k.value);
       }
+      ctx.require(':');
+      let v = ctx.parse();
       obj[k.value] = v;
     } while (ctx.attempt(','));
     ctx.require('}');

--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -280,11 +280,22 @@ infixRules['||'] = infixRules['&&'] = (left, token, ctx) => {
 infixRules['in'] = (left, token, ctx) => {
   let right = ctx.parse('in');
   if (isObject(right) && !isArray(right)) {
+    if (isNumber(left)) {
+      throw expectationError('Infix: in', 'String query on Object');
+    }
     right = Object.keys(right);
   }
 
   if (!(isArray(right) || isString(right))) {
     throw expectationError('Infix: in', 'array/string/object to perform lookup');
+  }
+
+  if (isArray(right) && !(isNumber(left) || isString(left))) {
+    throw expectationError('Infix: in', 'String/Number query on Array');
+  }
+
+  if (isString(right) && !isString(left)) {
+    throw expectationError('Infix: in', 'String query on String');
   }
 
   return right.indexOf(left) !== -1;

--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -124,11 +124,11 @@ let testComparisonOperands = (operator, left, right) => {
   return;
 };
 
-let testMathOperand = (operator, operand) => {
-  if (operator === '+' && !(isNumber(operand) || isString(operand))) {
+let testMathOperands = (operator, left, right) => {
+  if (operator === '+' && !(isNumber(left) && isNumber(right) || isString(left) && isString(right))) {
     throw expectationError('infix: +', 'number/string + number/string'); 
   } 
-  if (['-', '*', '/', '**'].some(v => v === operator) && !isNumber(operand)) {
+  if (['-', '*', '/', '**'].some(v => v === operator) && !(isNumber(left) && isNumber(right))) {
     throw expectationError(`infix: ${operator}`, `number ${operator} number`);
   }
   return;
@@ -213,12 +213,8 @@ prefixRules['false'] = (token, ctx) => {
 infixRules['+'] = infixRules['-'] = infixRules['*'] = infixRules['/']
   = (left, token, ctx) => {
     let operator = token.kind;
-    testMathOperand(operator, left);
     let right = ctx.parse(operator);
-    testMathOperand(operator, right);
-    if (typeof left !== typeof right) {
-      throw new InterpreterError(`TypeError: ${typeof left} ${operator} ${typeof right}`);
-    }
+    testMathOperands(operator, left, right);
     switch (operator) {
       case '+':  return left + right;
       case '-':  return left - right;
@@ -230,9 +226,8 @@ infixRules['+'] = infixRules['-'] = infixRules['*'] = infixRules['/']
 
 infixRules['**'] = (left, token, ctx) => {
   let operator = token.kind;
-  testMathOperand(operator, left);
   let right = ctx.parse('**-right-associative');
-  testMathOperand(operator, right);
+  testMathOperands(operator, left, right);
   if (typeof left !== typeof right) {
     throw new InterpreterError(`TypeError: ${typeof left} ${operator} ${typeof right}`);
   }

--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -224,7 +224,6 @@ infixRules['+'] = infixRules['-'] = infixRules['*'] = infixRules['/']
       case '-':  return left - right;
       case '*':  return left * right;
       case '/':  return left / right;
-      case '**': return Math.pow(left, right);
       default: throw new Error(`unknown infix operator: '${operator}'`);
     }
   };

--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -128,7 +128,7 @@ let testMathOperand = (operator, operand) => {
   if (operator === '+' && !(isNumber(operand) || isString(operand))) {
     throw expectationError('infix: +', 'number/string + number/string'); 
   } 
-  if (['-', '*', '/'].some(v => v === operator) && !isNumber(operand)) {
+  if (['-', '*', '/', '**'].some(v => v === operator) && !isNumber(operand)) {
     throw expectationError(`infix: ${operator}`, `number ${operator} number`);
   }
   return;
@@ -210,7 +210,7 @@ prefixRules['false'] = (token, ctx) => {
 };
 
 // infix rule definition starts here
-infixRules['+'] = infixRules['-'] = infixRules['*'] = infixRules['/']
+infixRules['+'] = infixRules['-'] = infixRules['*'] = infixRules['/'] = infixRules['**']
   = (left, token, ctx) => {
     testMathOperand(token.value, left);
     let right = ctx.parse(token.value);
@@ -219,10 +219,11 @@ infixRules['+'] = infixRules['-'] = infixRules['*'] = infixRules['/']
       throw new InterpreterError(`TypeError: ${typeof left} ${token.value} ${typeof right}`);
     }
     switch (token.value) {
-      case '+': return left + right;
-      case '-': return left - right;
-      case '*': return left * right;
-      case '/': return left / right;
+      case '+':  return left + right;
+      case '-':  return left - right;
+      case '*':  return left * right;
+      case '/':  return left / right;
+      case '**': return Math.pow(left, right);
       default: throw new Error(`unknown infix operator: '${operator}'`);
     }
   };
@@ -297,7 +298,7 @@ module.exports = new PrattParser({
     string:     '\'[^\']*\'|"[^"]*"',
   },
   tokens: [
-    ...'+-*/[].(){}:,'.split(''),
+    '**', ...'+-*/[].(){}:,'.split(''),
     '>=', '<=', '<', '>', '==', '!=', '!', '&&', '||',
     'true', 'false', 'in', 'number', 'identifier', 'string',
   ],
@@ -309,6 +310,7 @@ module.exports = new PrattParser({
   	['>=', '<=', '<', '>'],
     ['+', '-'],
     ['*', '/'],
+    ['**'],
     ['[', '.'],
     ['('],
     ['unary'],

--- a/test/expression-language.yml
+++ b/test/expression-language.yml
@@ -408,7 +408,7 @@ context: {key: 'aabc'}
 source: '"efg" in key'
 result: false
 ---
-title: 'in operator on string, failure (4)'
+title: 'in operator on string, failure (5)'
 context: {key: 'aabc'}
 source: '2 in key'
 result: false
@@ -455,12 +455,12 @@ result: false
 ---
 title: 'in operator on object, failure (5)'
 context: {}
-source: '3 in {'3': 1, "b": 2}'
+source: '3 in {"3": 1, "b": 2}'
 result: false
 ---
 title: 'in operator on object, failure (6)'
 context: {}
-source: '3.4 in {'3': 1, "b": 2}'
+source: '3.4 in {"3": 1, "b": 2}'
 result: false
 ---
 title: 'in operator on array, error (1)'
@@ -640,15 +640,55 @@ result: {a: 1, b: 2}
 ---
 title: 'parse object (2)'
 context: {key: 1}
+source: '{"a": key, b: key + 1}'
+result: {a: 1, b: 2}
+---
+title: 'parse object (3)'
+context: {key: 1}
+source: '{"a": key, "b": key + 1}'
+result: {a: 1, b: 2}
+---
+title: 'parse object (4)'
+context: {key: 1}
 source: '{"a": key, b: [key,key+1,key+2]}'
 result: {a: 1, b: [1,2,3]}
 ---
-title: 'parse object (3)'
+title: 'parse object (5)'
+context: {key: 1}
+source: '{a: key, "b": [key,key+1,key+2]}'
+result: {a: 1, b: [1,2,3]}
+---
+title: 'parse object (6)'
+context: {key: 1}
+source: '{"a": key, "b": [key,key+1,key+2]}'
+result: {a: 1, b: [1,2,3]}
+---
+title: 'parse object (7)'
+context: {key: 1}
+source: '{a: key, b: [key,key+1,key+2]}'
+result: {a: 1, b: [1,2,3]}
+---
+title: 'parse object (8)'
 context: {key: 1}
 source: '{a: key, b: min(key + 1, 1)}'
 result: {a: 1, b: 1}
 ---
-title: 'parse object (4)'
+title: 'parse object (9)'
+context: {key: 1}
+source: '{"a": key, b: min(key + 1, 1)}'
+result: {a: 1, b: 1}
+---
+title: 'parse object (10)'
+context: {key: 1}
+source: '{a: key, "b": min(key + 1, 1)}'
+result: {a: 1, b: 1}
+---
+title: 'parse object (11)'
+context: {key: 1}
+source: '{"a": key, "b": min(key + 1, 1)}'
+result: {a: 1, b: 1}
+---
+title: 'parse object (12)'
 context: {key: 1}
 source: '{a: key, b: key + 1'
 error: true

--- a/test/expression-language.yml
+++ b/test/expression-language.yml
@@ -368,6 +368,66 @@ context: {a: 3, b: 2}
 source: 'min(3, 2) + max(3, 2)'
 result: 5
 ---
+title: 'in operator on string, success (1)'
+context: {}
+source: '"abc" in "aabc"'
+result: true
+---
+title: 'in operator on string, failure (2)'
+context: {}
+source: '"efg" in "aabc"'
+result: false
+---
+title: 'in operator on string, success (3)'
+context: {key: 'aabc'}
+source: '"abc" in key'
+result: true
+---
+title: 'in operator on string, failure (4)'
+context: {key: 'aabc'}
+source: '"efg" in key'
+result: false
+---
+title: 'in operator on array, success (1)'
+context: {}
+source: '"abc" in [1, "abc", "def"]'
+result: true
+---
+title: 'in operator on array, failure (2)'
+context: {}
+source: '"efg" in [1, "abc", "def"]'
+result: false
+---
+title: 'in operator on array, success (3)'
+context: {key: [1, 'abc', 'def']}
+source: '"abc" in key'
+result: true
+---
+title: 'in operator on array, failure (4)'
+context: {key: [1, 'abc', 'def']}
+source: '"efg" in key'
+result: false
+---
+title: 'in operator on object, success (1)'
+context: {}
+source: '"a" in {"a": 1, b: 2}'
+result: true
+---
+title: 'in operator on object, failure (2)'
+context: {}
+source: '3 in {a: 1, "b": 2}'
+result: false
+---
+title: 'in operator on object, success (3)'
+context: {key: {a: 1, b: 2}}
+source: '"a" in key'
+result: true
+---
+title: 'in operator on object, failure (4)'
+context: {key: {a: 1, b: 2}}
+source: '"c" in key'
+result: false
+---
 title: 'equality (1)'
 context: {a: 1, b: 1}
 source: '1 == 1'
@@ -530,12 +590,12 @@ error: true
 ---
 title: 'parse object (1)'
 context: {key: 1}
-source: '{a: key, b: key + 1}'
+source: '{a: key, "b": key + 1}'
 result: {a: 1, b: 2}
 ---
 title: 'parse object (2)'
 context: {key: 1}
-source: '{a: key, b: [key,key+1,key+2]}'
+source: '{"a": key, b: [key,key+1,key+2]}'
 result: {a: 1, b: [1,2,3]}
 ---
 title: 'parse object (3)'

--- a/test/expression-language.yml
+++ b/test/expression-language.yml
@@ -408,6 +408,11 @@ context: {key: 'aabc'}
 source: '"efg" in key'
 result: false
 ---
+title: 'in operator on string, failure (4)'
+context: {key: 'aabc'}
+source: '2 in key'
+result: false
+---
 title: 'in operator on array, success (1)'
 context: {}
 source: '"abc" in [1, "abc", "def"]'
@@ -447,6 +452,26 @@ title: 'in operator on object, failure (4)'
 context: {key: {a: 1, b: 2}}
 source: '"c" in key'
 result: false
+---
+title: 'in operator on object, failure (5)'
+context: {}
+source: '3 in {'3': 1, "b": 2}'
+result: false
+---
+title: 'in operator on object, failure (6)'
+context: {}
+source: '3.4 in {'3': 1, "b": 2}'
+result: false
+---
+title: 'in operator on array, error (1)'
+context: {key: {a: 1, b: 2}}
+source: '[] in key'
+error: true
+---
+title: 'in operator on array, error (2)'
+context: {key: {a: 1, b: 2}}
+source: '{} in key'
+error: true
 ---
 title: 'equality (1)'
 context: {a: 1, b: 1}

--- a/test/expression-language.yml
+++ b/test/expression-language.yml
@@ -48,6 +48,26 @@ context: {a: 2, b: 3}
 source: 'a * a ** b'
 result: 16
 ---
+title: 'exponentiation, right associativity (1)'
+context: {a: 2, b: 3}
+source: 'a ** a ** b == a ** (a ** b)'
+result: true
+---
+title: 'exponentiation, right associativity (2)'
+context: {a: 2, b: 3}
+source: 'a ** a ** b'
+result: 256
+---
+title: 'exponentiation, right associativity (3)'
+context: {a: 2, b: 3}
+source: '2 ** 2 ** 3 == 2 ** (2 ** 3)'
+result: true
+---
+title: 'exponentiation, right associativity (4)'
+context: {a: 2, b: 3}
+source: '2 ** 2 ** 3'
+result: 256
+---
 title: 'logical not (1)'
 context: {tt: true, ff: false}
 source: '!tt'

--- a/test/expression-language.yml
+++ b/test/expression-language.yml
@@ -28,6 +28,26 @@ context: {a: 3.0, b: 2.0}
 source: 'b / a'
 result: 0.6666666666666666
 ---
+title: 'exponentiation (1)'
+context: {a: 2, b: 3}
+source: 'a ** b'
+result: 8
+---
+title: 'exponentiation (2)'
+context: {a: 2, b: 3}
+source: 'a ** b + 2'
+result: 10
+---
+title: 'exponentiation (3)'
+context: {a: 2, b: 3}
+source: 'a ** b * 2'
+result: 16
+---
+title: 'exponentiation (4)'
+context: {a: 2, b: 3}
+source: 'a * a ** b'
+result: 16
+---
 title: 'logical not (1)'
 context: {tt: true, ff: false}
 source: '!tt'
@@ -676,6 +696,16 @@ error: true
 title: 'Infix / type error'
 context: {}
 source: '3 / "hello"'
+error: true
+---
+title: 'Infix ** type error'
+context: {}
+source: '"hello" ** 3'
+error: true
+---
+title: 'Infix ** type error'
+context: {}
+source: '3 ** "hello"'
 error: true
 ---
 title: 'Infix < type error'

--- a/test/expression-language.yml
+++ b/test/expression-language.yml
@@ -68,6 +68,31 @@ context: {a: 2, b: 3}
 source: '2 ** 2 ** 3'
 result: 256
 ---
+title: 'TypeError: exponentiation (1)'
+context: {a: 'hello', b: 2}
+source: 'a ** b'
+error: true
+---
+title: 'TypeError: exponentiation (2)'
+context: {a: 'hello', b: 2}
+source: 'b ** a'
+error: true
+---
+title: 'TypeError: exponentiation (3)'
+context: {a: 'hello', b: 2}
+source: '"hello" ** b'
+error: true
+---
+title: 'TypeError: exponentiation (4)'
+context: {a: 'hello', b: 2}
+source: 'b ** "hello"'
+error: true
+---
+title: 'TypeError: exponentiation (5)'
+context: {a: 'hello', b: 2}
+source: '2 ** "hello"'
+error: true
+---
 title: 'logical not (1)'
 context: {tt: true, ff: false}
 source: '!tt'

--- a/test/expression-language.yml
+++ b/test/expression-language.yml
@@ -410,7 +410,7 @@ result: false
 ---
 title: 'in operator on string, failure (5)'
 context: {key: 'aabc'}
-source: '2 in key'
+source: '"2" in key'
 result: false
 ---
 title: 'in operator on array, success (1)'
@@ -418,19 +418,39 @@ context: {}
 source: '"abc" in [1, "abc", "def"]'
 result: true
 ---
-title: 'in operator on array, failure (2)'
+title: 'in operator on array, success (2)'
 context: {}
-source: '"efg" in [1, "abc", "def"]'
-result: false
+source: '1 in [1, "abc", "def"]'
+result: true
 ---
 title: 'in operator on array, success (3)'
 context: {key: [1, 'abc', 'def']}
 source: '"abc" in key'
 result: true
 ---
-title: 'in operator on array, failure (4)'
+title: 'in operator on array, success (3)'
+context: {key: [1, 'abc', 'def']}
+source: '1 in key'
+result: true
+---
+title: 'in operator on array, failure (1)'
+context: {}
+source: '"efg" in [1, "abc", "def"]'
+result: false
+---
+title: 'in operator on array, failure (2)'
+context: {}
+source: '2 in [1, "abc", "def"]'
+result: false
+---
+title: 'in operator on array, failure (2)'
 context: {key: [1, 'abc', 'def']}
 source: '"efg" in key'
+result: false
+---
+title: 'in operator on array, failure (4)'
+context: {key: [1, 'abc', 'def']}
+source: '2 in key'
 result: false
 ---
 title: 'in operator on object, success (1)'
@@ -438,38 +458,73 @@ context: {}
 source: '"a" in {"a": 1, b: 2}'
 result: true
 ---
-title: 'in operator on object, failure (2)'
-context: {}
-source: '3 in {a: 1, "b": 2}'
-result: false
----
-title: 'in operator on object, success (3)'
+title: 'in operator on object, success (2)'
 context: {key: {a: 1, b: 2}}
 source: '"a" in key'
 result: true
 ---
-title: 'in operator on object, failure (4)'
+title: 'in operator on object, success (3)'
+context: {}
+source: '"3.4" in {"3.4": 1, "b": 2}'
+result: true
+---
+title: 'in operator on object, failure (1)'
+context: {}
+source: '"c" in {a: 1, "b": 2}'
+result: false
+---
+title: 'in operator on object, failure (2)'
 context: {key: {a: 1, b: 2}}
 source: '"c" in key'
 result: false
 ---
-title: 'in operator on object, failure (5)'
+title: 'in operator on object, failure (3)'
 context: {}
-source: '3 in {"3": 1, "b": 2}'
+source: '"a" in {"3": 1, "b": 2}'
 result: false
 ---
-title: 'in operator on object, failure (6)'
+title: 'in operator on object, failure (4)'
 context: {}
-source: '3.4 in {"3": 1, "b": 2}'
+source: '"3.4" in {"3": 1, "b": 2}'
 result: false
 ---
-title: 'in operator on array, error (1)'
+title: 'TypeError: in operator on Object, error (1)'
 context: {key: {a: 1, b: 2}}
 source: '[] in key'
 error: true
 ---
-title: 'in operator on array, error (2)'
+title: 'TypeError: in operator on Object, error (2)'
 context: {key: {a: 1, b: 2}}
+source: '{} in key'
+error: true
+---
+title: 'TypeError: in operator on Object, error (3)'
+context: {key: {a: 1, b: 2}}
+source: '1 in key'
+error: true
+---
+title: 'TypeError: in operator on Array, error (1)'
+context: {key: [2,3,4]}
+source: '[] in key'
+error: true
+---
+title: 'TypeError: in operator on String, error (1)'
+context: {key: 'hello world!'}
+source: '[] in key'
+error: true
+---
+title: 'TypeError: in operator on String, error (2)'
+context: {key: 'hello world!'}
+source: '{} in key'
+error: true
+---
+title: 'TypeError: in operator on String, error (3)'
+context: {key: 'hello world!'}
+source: '1 in key'
+error: true
+---
+title: 'TypeError: in operator on Array, error (2)'
+context: {key: [2,3,4]}
 source: '{} in key'
 error: true
 ---

--- a/test/interpreter_test.js
+++ b/test/interpreter_test.js
@@ -16,9 +16,9 @@ const builtinMethods = {
 suite('intepreter', () => {
   let rawexpr = fs.readFileSync(EXPR_SPEC, {encoding: 'utf8'});
   yaml.loadAll(rawexpr, c => test(c.title, () => {
+    let result;
     try {
-      let result = interpreter.parse(c.source, _.defaults({}, c.context, builtinMethods));
-      assume(result).eql(c.result);
+      result = interpreter.parse(c.source, _.defaults({}, c.context, builtinMethods));
     } catch (err) {
       if (!c.error) {
         throw err;
@@ -26,5 +26,6 @@ suite('intepreter', () => {
       return;
     }
     assert(!c.error, 'Expected an error from: ' + c.source);
+    assume(result).eql(c.result);
   }));
 });

--- a/test/jsone_test.js
+++ b/test/jsone_test.js
@@ -30,9 +30,9 @@ suite('json-e', () => {
   after(() => tk.reset());
 
   _.forEach(spec, (C, s) => suite(s, () => C.forEach(c => test(c.title, () => {
+    let result;
     try {
-      let result = jsone(c.template, _.defaults({}, c.context, builtinMethods));
-      assume(result).eql(c.result);
+      result = jsone(c.template, _.defaults({}, c.context, builtinMethods));
     } catch (err) {
       if (!c.error) {
         throw err;
@@ -40,5 +40,6 @@ suite('json-e', () => {
       return;
     }
     assert(!c.error, 'Expected an error');
+    assume(result).eql(c.result);
   }))));
 });


### PR DESCRIPTION
This PR is aimed at resolving #33, #34  and fixing bug which allows parsing for objects like ```{"a": 123, "b": 456}```.