### PR TITLE
Don't upload the gh-pages docs/ directory to docs.tc.net

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -60,7 +60,7 @@ tasks:
           cd repo &&
           git config advice.detachedHead false &&
           git checkout {{event.head.sha}} &&
-          export DEBUG=* DOCS_PROJECT=json-e DOCS_TIER=libraries DOCS_FOLDER=docs DOCS_README=README.md &&
+          export DEBUG=* DOCS_PROJECT=json-e DOCS_TIER=libraries DOCS_FOLDER=tc-docs DOCS_README=README.md &&
           upload-project-docs
     metadata:
       name: "json-e docs upload"


### PR DESCRIPTION
Instead, specify DOCS_FOLDER=tc-docs, which doesn't exist. Then we will
only upload the README.