### PR TITLE
Add tests for some corner cases

### DIFF
--- a/python-blacklist.txt
+++ b/python-blacklist.txt
@@ -364,3 +364,447 @@ expression language - errors: Infix or type error (1)
 expression language - errors: Infix or type error (2)
 expression language - errors: Infix and type error (1)
 expression language - errors: Infix and type error (2)
+Initial Minimal Subset: string interpolation escapes
+Initial Minimal Subset: string interpolation with unbalanced }
+Initial Minimal Subset: booleans interpolate
+Initial Minimal Subset: numbers interpolate
+Initial Minimal Subset: nulls interpolate
+$if-constructs: $if->then->else, empty string
+$if-constructs: $if->then->else, nonempty string
+$if-constructs: $if->then->else, string "0"
+$if-constructs: $if->then->else, zero
+$if-constructs: $if->then->else, one
+$if-constructs: $if->then->else, null
+$if-constructs: $if->then->else, empty array
+$if-constructs: $if->then->else, nonempty array
+$if-constructs: $if->then->else, empty object
+$if-constructs: $if->then->else, nonempty object
+$if-constructs: $if->then evaluating to nothing at the top level is an error
+$map: $map requires an array, not object
+$map: $map requires an array, not string
+$map: $map requires an array, not number
+$map: $map requires an array, not null
+$sort: simple sort of strings (shortest first)
+$sort: simple sort of multi-digit numbers
+$sort: sort by, returning number
+$sort: sort by, returning string
+$sort: by cannot return objects
+$sort: by cannot return arrays
+$sort: cannot sort nulls
+$sort: cannot sort nulls, even with by
+$sort: cannot sort booleans
+$sort: cannot sort booleans, even with by
+$sort: cannot sort numbers and strings together
+$sort: cannot sort numbers and strings together even with by
+$sort: sort requires an array (null)
+$reverse: reverse of an object
+$reverse: reverse of null
+$reverse: reverse of a string
+$reverse: reverse of a number
+$reverse: reverse of a boolean
+$eval: $eval of an array
+$eval: $eval of an object
+$eval: $eval of null
+$eval: $eval of a number
+$eval: $eval of a boolean
+builtins: min - TypeError
+builtins: min (7)
+builtins: max - TypeError
+builtins: max (7)
+builtins: sqrt - TypeError
+builtins: ceil - TypeError
+builtins: floor - TypeError
+builtins: abs - TypeError
+builtins: fromNow
+builtins: fromNow - 2 days 3 hours
+builtins: fromNow - TypeError
+expression language - basics: decimal literal
+expression language - basics: hex literal
+expression language - basics: string literal with single quote
+expression language - basics: string literal with double quote
+expression language - basics: boolean literals
+expression language - basics: null literal
+expression language - basics: leading zeroes (not octal)
+expression language - arithmetic: addition
+expression language - arithmetic: multiplication
+expression language - arithmetic: division (1)
+expression language - arithmetic: division (2)
+expression language - arithmetic: division (3)
+expression language - arithmetic: division (4)
+expression language - arithmetic: exponentiation (1)
+expression language - arithmetic: exponentiation (2)
+expression language - arithmetic: exponentiation (3)
+expression language - arithmetic: exponentiation (4)
+expression language - arithmetic: exponentiation, right associativity (1)
+expression language - arithmetic: exponentiation, right associativity (2)
+expression language - arithmetic: exponentiation, right associativity (3)
+expression language - arithmetic: exponentiation, right associativity (4)
+expression language - arithmetic: unary negation
+expression language - arithmetic: unary plus
+expression language - operator type errors: addition of strings to numbers
+expression language - operator type errors: addition of strings to null
+expression language - operator type errors: addition of strings to booleans
+expression language - operator type errors: addition of strings to objects
+expression language - operator type errors: addition of strings to arrays
+expression language - operator type errors: subtraction of strings from strings
+expression language - operator type errors: subtraction of strings from numbers
+expression language - operator type errors: subtraction of strings from null
+expression language - operator type errors: subtraction of strings from booleans
+expression language - operator type errors: subtraction of strings from objects
+expression language - operator type errors: subtraction of strings from arrays
+expression language - operator type errors: multiplication of strings to strings
+expression language - operator type errors: multiplication of strings to numbers
+expression language - operator type errors: multiplication of strings to null
+expression language - operator type errors: multiplication of strings to booleans
+expression language - operator type errors: multiplication of strings to objects
+expression language - operator type errors: multiplication of strings to arrays
+expression language - operator type errors: division of strings by strings
+expression language - operator type errors: division of strings by numbers
+expression language - operator type errors: division of strings by null
+expression language - operator type errors: division of strings by booleans
+expression language - operator type errors: division of strings by objects
+expression language - operator type errors: division of strings by arrays
+expression language - operator type errors: exponentiation of strings by strings
+expression language - operator type errors: exponentiation of strings by numbers
+expression language - operator type errors: exponentiation of strings by null
+expression language - operator type errors: exponentiation of strings by booleans
+expression language - operator type errors: exponentiation of strings by objects
+expression language - operator type errors: exponentiation of strings by arrays
+expression language - operator type errors: unary negation of string
+expression language - operator type errors: unary plus of string
+expression language - operator type errors: addition of numbers to strings
+expression language - operator type errors: addition of numbers to null
+expression language - operator type errors: addition of numbers to booleans
+expression language - operator type errors: addition of numbers to objects
+expression language - operator type errors: addition of numbers to arrays
+expression language - operator type errors: subtraction of numbers from strings
+expression language - operator type errors: subtraction of numbers from null
+expression language - operator type errors: subtraction of numbers from booleans
+expression language - operator type errors: subtraction of numbers from objects
+expression language - operator type errors: subtraction of numbers from arrays
+expression language - operator type errors: multiplication of numbers to strings
+expression language - operator type errors: multiplication of numbers to null
+expression language - operator type errors: multiplication of numbers to booleans
+expression language - operator type errors: multiplication of numbers to objects
+expression language - operator type errors: multiplication of numbers to arrays
+expression language - operator type errors: division of numbers by strings
+expression language - operator type errors: division of numbers by null
+expression language - operator type errors: division of numbers by booleans
+expression language - operator type errors: division of numbers by objects
+expression language - operator type errors: division of numbers by arrays
+expression language - operator type errors: exponentiation of numbers by strings
+expression language - operator type errors: exponentiation of numbers by null
+expression language - operator type errors: exponentiation of numbers by booleans
+expression language - operator type errors: exponentiation of numbers by objects
+expression language - operator type errors: exponentiation of numbers by arrays
+expression language - operator type errors: addition of null to strings
+expression language - operator type errors: addition of null to numbers
+expression language - operator type errors: addition of null to null
+expression language - operator type errors: addition of null to booleans
+expression language - operator type errors: addition of null to objects
+expression language - operator type errors: addition of null to arrays
+expression language - operator type errors: subtraction of null from strings
+expression language - operator type errors: subtraction of null from numbers
+expression language - operator type errors: subtraction of null from null
+expression language - operator type errors: subtraction of null from booleans
+expression language - operator type errors: subtraction of null from objects
+expression language - operator type errors: subtraction of null from arrays
+expression language - operator type errors: multiplication of null to strings
+expression language - operator type errors: multiplication of null to numbers
+expression language - operator type errors: multiplication of null to null
+expression language - operator type errors: multiplication of null to booleans
+expression language - operator type errors: multiplication of null to objects
+expression language - operator type errors: multiplication of null to arrays
+expression language - operator type errors: division of null by strings
+expression language - operator type errors: division of null by numbers
+expression language - operator type errors: division of null by null
+expression language - operator type errors: division of null by booleans
+expression language - operator type errors: division of null by objects
+expression language - operator type errors: division of null by arrays
+expression language - operator type errors: exponentiation of null by strings
+expression language - operator type errors: exponentiation of null by numbers
+expression language - operator type errors: exponentiation of null by null
+expression language - operator type errors: exponentiation of null by booleans
+expression language - operator type errors: exponentiation of null by objects
+expression language - operator type errors: exponentiation of null by arrays
+expression language - operator type errors: unary negation of null
+expression language - operator type errors: unary plus of null
+expression language - operator type errors: addition of boolean to strings
+expression language - operator type errors: addition of boolean to numbers
+expression language - operator type errors: addition of boolean to null
+expression language - operator type errors: addition of boolean to booleans
+expression language - operator type errors: addition of boolean to objects
+expression language - operator type errors: addition of boolean to arrays
+expression language - operator type errors: subtraction of boolean from strings
+expression language - operator type errors: subtraction of boolean from numbers
+expression language - operator type errors: subtraction of boolean from null
+expression language - operator type errors: subtraction of boolean from booleans
+expression language - operator type errors: subtraction of boolean from objects
+expression language - operator type errors: subtraction of boolean from arrays
+expression language - operator type errors: multiplication of boolean to strings
+expression language - operator type errors: multiplication of boolean to numbers
+expression language - operator type errors: multiplication of boolean to null
+expression language - operator type errors: multiplication of boolean to booleans
+expression language - operator type errors: multiplication of boolean to objects
+expression language - operator type errors: multiplication of boolean to arrays
+expression language - operator type errors: division of boolean by strings
+expression language - operator type errors: division of boolean by numbers
+expression language - operator type errors: division of boolean by null
+expression language - operator type errors: division of boolean by booleans
+expression language - operator type errors: division of boolean by objects
+expression language - operator type errors: division of boolean by arrays
+expression language - operator type errors: exponentiation of boolean by strings
+expression language - operator type errors: exponentiation of boolean by numbers
+expression language - operator type errors: exponentiation of boolean by null
+expression language - operator type errors: exponentiation of boolean by booleans
+expression language - operator type errors: exponentiation of boolean by objects
+expression language - operator type errors: exponentiation of boolean by arrays
+expression language - operator type errors: unary negation of boolean
+expression language - operator type errors: unary plus of boolean
+expression language - operator type errors: addition of object to strings
+expression language - operator type errors: addition of object to numbers
+expression language - operator type errors: addition of object to null
+expression language - operator type errors: addition of object to booleans
+expression language - operator type errors: addition of object to objects
+expression language - operator type errors: addition of object to arrays
+expression language - operator type errors: subtraction of object from strings
+expression language - operator type errors: subtraction of object from numbers
+expression language - operator type errors: subtraction of object from null
+expression language - operator type errors: subtraction of object from booleans
+expression language - operator type errors: subtraction of object from objects
+expression language - operator type errors: subtraction of object from arrays
+expression language - operator type errors: multiplication of object to strings
+expression language - operator type errors: multiplication of object to numbers
+expression language - operator type errors: multiplication of object to null
+expression language - operator type errors: multiplication of object to booleans
+expression language - operator type errors: multiplication of object to objects
+expression language - operator type errors: multiplication of object to arrays
+expression language - operator type errors: division of object by strings
+expression language - operator type errors: division of object by numbers
+expression language - operator type errors: division of object by null
+expression language - operator type errors: division of object by booleans
+expression language - operator type errors: division of object by objects
+expression language - operator type errors: division of object by arrays
+expression language - operator type errors: exponentiation of object by strings
+expression language - operator type errors: exponentiation of object by numbers
+expression language - operator type errors: exponentiation of object by null
+expression language - operator type errors: exponentiation of object by booleans
+expression language - operator type errors: exponentiation of object by objects
+expression language - operator type errors: exponentiation of object by arrays
+expression language - operator type errors: unary negation of object
+expression language - operator type errors: unary plus of object
+expression language - operator type errors: addition of array to strings
+expression language - operator type errors: addition of array to numbers
+expression language - operator type errors: addition of array to null
+expression language - operator type errors: addition of array to booleans
+expression language - operator type errors: addition of array to objects
+expression language - operator type errors: addition of array to arrays
+expression language - operator type errors: subtraction of array from strings
+expression language - operator type errors: subtraction of array from numbers
+expression language - operator type errors: subtraction of array from null
+expression language - operator type errors: subtraction of array from booleans
+expression language - operator type errors: subtraction of array from objects
+expression language - operator type errors: subtraction of array from arrays
+expression language - operator type errors: multiplication of array to strings
+expression language - operator type errors: multiplication of array to numbers
+expression language - operator type errors: multiplication of array to null
+expression language - operator type errors: multiplication of array to booleans
+expression language - operator type errors: multiplication of array to objects
+expression language - operator type errors: multiplication of array to arrays
+expression language - operator type errors: division of array by strings
+expression language - operator type errors: division of array by numbers
+expression language - operator type errors: division of array by null
+expression language - operator type errors: division of array by booleans
+expression language - operator type errors: division of array by objects
+expression language - operator type errors: division of array by arrays
+expression language - operator type errors: exponentiation of array by strings
+expression language - operator type errors: exponentiation of array by numbers
+expression language - operator type errors: exponentiation of array by null
+expression language - operator type errors: exponentiation of array by booleans
+expression language - operator type errors: exponentiation of array by objects
+expression language - operator type errors: exponentiation of array by arrays
+expression language - operator type errors: unary negation of array
+expression language - operator type errors: unary plus of array
+expression language - logic: string not
+expression language - logic: number not
+expression language - logic: null not
+expression language - logic: object not
+expression language - logic: array not
+expression language - logic: string and string
+expression language - logic: string or string
+expression language - logic: string and number
+expression language - logic: string or number
+expression language - logic: string and null
+expression language - logic: string or null
+expression language - logic: string and boolean
+expression language - logic: string or boolean
+expression language - logic: string and object
+expression language - logic: string or object
+expression language - logic: string and array
+expression language - logic: string or array
+expression language - logic: number and string
+expression language - logic: number or string
+expression language - logic: number and number
+expression language - logic: number or number
+expression language - logic: number and null
+expression language - logic: number or null
+expression language - logic: number and boolean
+expression language - logic: number or boolean
+expression language - logic: number and object
+expression language - logic: number or object
+expression language - logic: number and array
+expression language - logic: number or array
+expression language - logic: null and string
+expression language - logic: null or string
+expression language - logic: null and number
+expression language - logic: null or number
+expression language - logic: null and null
+expression language - logic: null or null
+expression language - logic: null and boolean
+expression language - logic: null or boolean
+expression language - logic: null and object
+expression language - logic: null or object
+expression language - logic: null and array
+expression language - logic: null or array
+expression language - logic: boolean and string
+expression language - logic: boolean or string
+expression language - logic: boolean and number
+expression language - logic: boolean or number
+expression language - logic: boolean and null
+expression language - logic: boolean or null
+expression language - logic: boolean and boolean
+expression language - logic: boolean or boolean
+expression language - logic: boolean and object
+expression language - logic: boolean or object
+expression language - logic: boolean and array
+expression language - logic: boolean or array
+expression language - logic: object and string
+expression language - logic: object or string
+expression language - logic: object and number
+expression language - logic: object or number
+expression language - logic: object and null
+expression language - logic: object or null
+expression language - logic: object and boolean
+expression language - logic: object or boolean
+expression language - logic: object and object
+expression language - logic: object or object
+expression language - logic: object and array
+expression language - logic: object or array
+expression language - logic: array and string
+expression language - logic: array or string
+expression language - logic: array and number
+expression language - logic: array or number
+expression language - logic: array and null
+expression language - logic: array or null
+expression language - logic: array and boolean
+expression language - logic: array or boolean
+expression language - logic: array and object
+expression language - logic: array or object
+expression language - logic: array and array
+expression language - logic: array or array
+expression language - string operations: string length attribute
+expression language - string operations: other string attributes are not set
+expression language - property access: missing property
+expression language - property access: missing property by name
+expression language - property access: property access with expression value
+expression language - property access: property of number
+expression language - property access: property of null
+expression language - property access: property of boolean
+expression language - property access: property of array
+expression language - array access: indexing number
+expression language - array access: indexing null
+expression language - array access: indexing boolean
+expression language - array access: indexing object
+expression language - array access: array length
+expression language - array access: other array attributes are not available
+expression language - array slicing: slicing number
+expression language - array slicing: slicing null
+expression language - array slicing: slicing boolean
+expression language - array slicing: slicing object
+expression language - comparisons: deep object equality
+expression language - comparisons: boolean equality
+expression language - comparisons: null equality
+expression language - comparisons: string equality
+expression language - comparisons: deep object inequality
+expression language - comparisons: deep array equality
+expression language - comparisons: deep array inequality
+expression language - comparisons: ordering of string and string
+expression language - comparisons: ordering of string and number
+expression language - comparisons: ordering of string and null
+expression language - comparisons: ordering of string and boolean
+expression language - comparisons: ordering of string and object
+expression language - comparisons: ordering of string and array
+expression language - comparisons: ordering of number and string
+expression language - comparisons: ordering of number and number
+expression language - comparisons: ordering of number and null
+expression language - comparisons: ordering of number and boolean
+expression language - comparisons: ordering of number and object
+expression language - comparisons: ordering of number and array
+expression language - comparisons: ordering of null and string
+expression language - comparisons: ordering of null and number
+expression language - comparisons: ordering of null and null
+expression language - comparisons: ordering of null and boolean
+expression language - comparisons: ordering of null and object
+expression language - comparisons: ordering of null and array
+expression language - comparisons: ordering of boolean and string
+expression language - comparisons: ordering of boolean and number
+expression language - comparisons: ordering of boolean and null
+expression language - comparisons: ordering of boolean and boolean
+expression language - comparisons: ordering of boolean and object
+expression language - comparisons: ordering of boolean and array
+expression language - comparisons: ordering of object and string
+expression language - comparisons: ordering of object and number
+expression language - comparisons: ordering of object and null
+expression language - comparisons: ordering of object and boolean
+expression language - comparisons: ordering of object and object
+expression language - comparisons: ordering of object and array
+expression language - comparisons: ordering of array and string
+expression language - comparisons: ordering of array and number
+expression language - comparisons: ordering of array and null
+expression language - comparisons: ordering of array and boolean
+expression language - comparisons: ordering of array and array
+expression language - comparisons: ordering of array and array
+expression language - comparisons: equality of string and string
+expression language - comparisons: equality of string and number
+expression language - comparisons: equality of string and null
+expression language - comparisons: equality of string and boolean
+expression language - comparisons: equality of string and object
+expression language - comparisons: equality of string and array
+expression language - comparisons: equality of number and string
+expression language - comparisons: equality of number and number
+expression language - comparisons: equality of number and null
+expression language - comparisons: equality of number and boolean
+expression language - comparisons: equality of number and object
+expression language - comparisons: equality of number and array
+expression language - comparisons: equality of null and string
+expression language - comparisons: equality of null and number
+expression language - comparisons: equality of null and null
+expression language - comparisons: equality of null and boolean
+expression language - comparisons: equality of null and object
+expression language - comparisons: equality of null and array
+expression language - comparisons: equality of boolean and string
+expression language - comparisons: equality of boolean and number
+expression language - comparisons: equality of boolean and null
+expression language - comparisons: equality of boolean and boolean
+expression language - comparisons: equality of boolean and object
+expression language - comparisons: equality of boolean and array
+expression language - comparisons: equality of object and string
+expression language - comparisons: equality of object and number
+expression language - comparisons: equality of object and null
+expression language - comparisons: equality of object and boolean
+expression language - comparisons: equality of object and object
+expression language - comparisons: equality of object and array
+expression language - comparisons: equality of array and string
+expression language - comparisons: equality of array and number
+expression language - comparisons: equality of array and null
+expression language - comparisons: equality of array and boolean
+expression language - comparisons: equality of array and object
+expression language - comparisons: equality of array and array
+expression language - string operations: string indexing (noninteger)
+expression language - string operations: string slicing (fractional first index)
+expression language - string operations: string slicing (fractional second index)
+expression language - string operations: string slicing (fractional indexes)
+expression language - array access: numeric, noninteger index
+expression language - array slicing: array slicing (noninteger first index)
+expression language - array slicing: array slicing (noninteger last index)
+expression language - array slicing: array slicing (noninteger indexes)

--- a/setup.py
+++ b/setup.py
@@ -6,14 +6,14 @@ def make_test_suite():
     import yaml
     import jsone
 
-    def todo(test):
+    def todo(test, reason):
         "Wrap a test that should not pass yet"
         def wrap():
             try:
                 test()
             except Exception:
-                raise unittest.SkipTest('blacklisted')
-            raise AssertionError("test passed unexpectedly - remove from python-blacklist.txt?")
+                raise unittest.SkipTest(reason)
+            raise AssertionError("test passed unexpectedly")
         return wrap
 
     def spec_test(spec):
@@ -57,7 +57,9 @@ def make_test_suite():
             name = '{}: {}'.format(section, spec['title'])
             t = spec_test(spec)
             if name in blacklist:
-                t = todo(t)
+                t = todo(t, 'blacklist')
+            elif 'todo' in spec:
+                t = todo(t, spec['todo'])
             test = Case(t, name)
             subsuite.addTest(test)
     return suite

--- a/specification.yml
+++ b/specification.yml
@@ -30,16 +30,6 @@ context:  {}
 template: {$fromNow: '2 days 3 hours'}
 result:   '2017-01-21T19:27:20.974Z'
 ---
-title:    fromNow built-in
-context:  {}
-template: {$eval: fromNow("")}
-result:   '2017-01-19T16:27:20.974Z'
----
-title:    fromNow built-in 2 days 3 hours
-context:  {}
-template: {$eval: fromNow("2 days 3 hours")}
-result:   '2017-01-21T19:27:20.974Z'
----
 title:    $eval
 context:  {key: ['value', 1, 2, true, {}]}
 template: {$eval: 'key'}
@@ -693,6 +683,11 @@ context: {key1: 1, key2: 2}
 template: {$eval: 'min(2, 1, 3, 4, 5)'}
 result: 1
 ---
+title: min - TypeError
+context: {}
+template: {$eval: 'min("11")'}
+error: true
+---
 title: min (7)
 context: {}
 template: {$eval: 'min()'}
@@ -729,6 +724,11 @@ context: {key1: 1, key2: 2}
 template: {$eval: 'max(2, 1, 3, 4, 5)'}
 result: 5
 ---
+title: max - TypeError
+context: {}
+template: {$eval: 'max("12")'}
+error: true
+---
 title: max (7)
 context: {}
 template: {$eval: 'max()'}
@@ -754,6 +754,11 @@ title: sqrt (3)
 context: {}
 template: {$eval: 'sqrt(9)'}
 result: 3.0
+---
+title: sqrt - TypeError
+context: {}
+template: {$eval: 'sqrt("nine")'}
+error: true
 ---
 title: ceil (1)
 context: {key: 1.1}
@@ -795,6 +800,11 @@ context: {key: 1.0}
 template: {$eval: 'ceil(key)'}
 result: 1.0
 ---
+title: ceil - TypeError
+context: {}
+template: {$eval: 'ceil(true)'}
+error: true
+---
 title: floor (1)
 context: {key: 1.1}
 template: {$eval: 'floor(key)'}
@@ -834,6 +844,11 @@ title: floor (8)
 context: {key: 1.0}
 template: {$eval: 'floor(key)'}
 result: 1.0
+---
+title: floor - TypeError
+context: {key: null}
+template: {$eval: 'floor(key)'}
+error: true
 ---
 title: abs (1)
 context: {key: -1.1}
@@ -934,6 +949,11 @@ title: abs (20)
 context: {}
 template: {$eval: 'abs(1.0)'}
 result: 1.0
+---
+title: abs - TypeError
+context: {}
+template: {$eval: 'abs({})'}
+error: true
 ---
 title: lowercase (1)
 context: {key: 'HEllo'}
@@ -1095,6 +1115,11 @@ context: {}
 template: {$eval: 'str(true)'}
 result: 'true'
 ---
+title: str (6)
+context: {x: null}
+template: {$eval: 'str(x)'}
+error: true
+---
 title: str (7)
 context: {key: false}
 template: {$eval: 'str(key)'}
@@ -1114,6 +1139,21 @@ title: str (10)
 context: {}
 template: {$eval: 'str([1, 2, 3])'}
 result: '1,2,3'
+---
+title:    fromNow
+context:  {}
+template: {$eval: fromNow("")}
+result:   '2017-01-19T16:27:20.974Z'
+---
+title:    fromNow - 2 days 3 hours
+context:  {}
+template: {$eval: fromNow("2 days 3 hours")}
+result:   '2017-01-21T19:27:20.974Z'
+---
+title:    fromNow - TypeError
+context:  {}
+template: {$eval: fromNow(13)}
+error: true
 ---
 title: override builtin (1), uppercase
 context: {uppercase: 1}

--- a/specification.yml
+++ b/specification.yml
@@ -80,6 +80,17 @@ context:  {a: 'hello', b: 'world'}
 template: {message: '${a}##${b}'}
 result:   {message: 'hello##world'}
 ---
+title: string interpolation escapes
+context:  {}
+template: {message: 'a literal \\${ in a string'}
+result:   {message: 'a literal ${ in a string'}
+todo: 'https://github.com/taskcluster/json-e/issues/66'
+---
+title: string interpolation with unbalanced }
+context:  {}
+template: {message: 'tricky ${"}}}}"}'}
+result:   {message: 'tricky }}}}'}
+---
 title:    can't interpolate arrays
 context:  {key: [1,2,3]}
 template: {message: 'hello ${key}'}

--- a/specification.yml
+++ b/specification.yml
@@ -602,6 +602,31 @@ context:  {}
 template: {$reverse: [3, 4, 1, 2]}
 result:   [2, 1, 4, 3]
 ---
+title:    reverse of an object
+context:  {}
+template: {$reverse: {a: 1}}
+error: true
+---
+title:    reverse of null
+context:  {}
+template: {$reverse: null}
+error: true
+---
+title:    reverse of a string
+context:  {}
+template: {$reverse: 'foo'}
+error: true
+---
+title:    reverse of a number
+context:  {}
+template: {$reverse: 1}
+error: true
+---
+title:    reverse of a boolean
+context:  {}
+template: {$reverse: true}
+error: true
+---
 title:    simple reverse with $eval
 context:  {key: [3, 4, 1, 2]}
 template: {$reverse: {$eval: 'key'}}
@@ -1986,6 +2011,415 @@ title: 'greater than equal (4)'
 context: {a: 1, b: 1}
 template: {$eval: "a >= b"}
 result: true
+---
+title: 'deep object equality'
+context:
+    a: {left: 1, right: {left: 2, right: 3}}
+    b: {left: 1, right: {left: 2, right: 3}}
+template: {$eval: "a == b"}
+result: true
+todo: 'https://github.com/taskcluster/json-e/issues/72'
+---
+title: 'boolean equality'
+context: {}
+template: {$eval: "true == true"}
+result: true
+---
+title: 'null equality'
+context: {a: null, b:  null}
+template: {$eval: "a == b"}
+result: true
+---
+title: 'string equality'
+context: {a: 'xyz', b:  'xyz'}
+template: {$eval: "a == b"}
+result: true
+---
+title: 'deep object inequality'
+context:
+    a: {left: 1, right: {left: 2, right: 3}}
+    b: {left: 1, right: {left: 3, right: 2}}
+template: {$eval: "a != b"}
+result: true
+todo: 'https://github.com/taskcluster/json-e/issues/72'
+---
+title: 'deep array equality'
+context:
+    a: [1, [2, 3]]
+    b: [1, [2, 3]]
+template: {$eval: "a == b"}
+result: true
+todo: 'https://github.com/taskcluster/json-e/issues/72'
+---
+title: 'deep array inequality'
+context:
+    a: [1, [2, 3]]
+    b: [1, [3, 2]]
+template: {$eval: "a != b"}
+result: true
+todo: 'https://github.com/taskcluster/json-e/issues/72'
+---
+title: ordering of string and string
+context: {a: 'abc', b: 'def'}
+template: {$eval: 'a < b'}
+result: true
+---
+title: ordering of string and number
+context: {a: 'abc', b: 27}
+template: {$eval: 'a < b'}
+error: true
+---
+title: ordering of string and null
+context: {a: 'abc', b: null}
+template: {$eval: 'a < b'}
+error: true
+---
+title: ordering of string and boolean
+context: {a: 'abc', b: true}
+template: {$eval: 'a < b'}
+error: true
+---
+title: ordering of string and object
+context: {a: 'abc', b: {}}
+template: {$eval: 'a < b'}
+error: true
+---
+title: ordering of string and array
+context: {a: 'abc', b: []}
+template: {$eval: 'a < b'}
+error: true
+---
+title: ordering of number and string
+context: {a: 123, b: 'def'}
+template: {$eval: 'a < b'}
+error: true
+---
+title: ordering of number and number
+context: {a: 123, b: 27}
+template: {$eval: 'a < b'}
+result: false
+---
+title: ordering of number and null
+context: {a: 123, b: null}
+template: {$eval: 'a < b'}
+error: true
+---
+title: ordering of number and boolean
+context: {a: 123, b: true}
+template: {$eval: 'a < b'}
+error: true
+---
+title: ordering of number and object
+context: {a: 123, b: {}}
+template: {$eval: 'a < b'}
+error: true
+---
+title: ordering of number and array
+context: {a: 123, b: []}
+template: {$eval: 'a < b'}
+error: true
+---
+title: ordering of null and string
+context: {a: null, b: 'def'}
+template: {$eval: 'a < b'}
+error: true
+---
+title: ordering of null and number
+context: {a: null, b: 27}
+template: {$eval: 'a < b'}
+error: true
+---
+title: ordering of null and null
+context: {a: null, b: null}
+template: {$eval: 'a < b'}
+error: true
+---
+title: ordering of null and boolean
+context: {a: null, b: true}
+template: {$eval: 'a < b'}
+error: true
+---
+title: ordering of null and object
+context: {a: null, b: {}}
+template: {$eval: 'a < b'}
+error: true
+---
+title: ordering of null and array
+context: {a: null, b: []}
+template: {$eval: 'a < b'}
+error: true
+---
+title: ordering of boolean and string
+context: {a: true, b: 'def'}
+template: {$eval: 'a < b'}
+error: true
+---
+title: ordering of boolean and number
+context: {a: true, b: 27}
+template: {$eval: 'a < b'}
+error: true
+---
+title: ordering of boolean and null
+context: {a: true, b: null}
+template: {$eval: 'a < b'}
+error: true
+---
+title: ordering of boolean and boolean
+context: {a: true, b: true}
+template: {$eval: 'a < b'}
+error: true
+---
+title: ordering of boolean and object
+context: {a: true, b: {}}
+template: {$eval: 'a < b'}
+error: true
+---
+title: ordering of boolean and array
+context: {a: true, b: []}
+template: {$eval: 'a < b'}
+error: true
+---
+title: ordering of object and string
+context: {a: {}, b: 'def'}
+template: {$eval: 'a < b'}
+error: true
+---
+title: ordering of object and number
+context: {a: {}, b: 27}
+template: {$eval: 'a < b'}
+error: true
+---
+title: ordering of object and null
+context: {a: {}, b: null}
+template: {$eval: 'a < b'}
+error: true
+---
+title: ordering of object and boolean
+context: {a: {}, b: true}
+template: {$eval: 'a < b'}
+error: true
+---
+title: ordering of object and object
+context: {a: {}, b: {}}
+template: {$eval: 'a < b'}
+error: true
+---
+title: ordering of object and array
+context: {a: {}, b: []}
+template: {$eval: 'a < b'}
+error: true
+---
+title: ordering of array and string
+context: {a: [], b: 'def'}
+template: {$eval: 'a < b'}
+error: true
+---
+title: ordering of array and number
+context: {a: [], b: 27}
+template: {$eval: 'a < b'}
+error: true
+---
+title: ordering of array and null
+context: {a: [], b: null}
+template: {$eval: 'a < b'}
+error: true
+---
+title: ordering of array and boolean
+context: {a: [], b: true}
+template: {$eval: 'a < b'}
+error: true
+---
+title: ordering of array and array
+context: {a: [], b: {}}
+template: {$eval: 'a < b'}
+error: true
+---
+title: ordering of array and array
+context: {a: [], b: []}
+template: {$eval: 'a < b'}
+error: true
+---
+title: equality of string and string
+context: {a: 'abc', b: 'def'}
+template: {$eval: 'a == b'}
+result: false
+---
+title: equality of string and number
+context: {a: 'abc', b: 27}
+template: {$eval: 'a == b'}
+result: false
+---
+title: equality of string and null
+context: {a: 'abc', b: null}
+template: {$eval: 'a == b'}
+result: false
+---
+title: equality of string and boolean
+context: {a: 'abc', b: true}
+template: {$eval: 'a == b'}
+result: false
+---
+title: equality of string and object
+context: {a: 'abc', b: {}}
+template: {$eval: 'a == b'}
+result: false
+---
+title: equality of string and array
+context: {a: 'abc', b: []}
+template: {$eval: 'a == b'}
+result: false
+---
+title: equality of number and string
+context: {a: 123, b: 'def'}
+template: {$eval: 'a == b'}
+result: false
+---
+title: equality of number and number
+context: {a: 123, b: 27}
+template: {$eval: 'a == b'}
+result: false
+---
+title: equality of number and null
+context: {a: 123, b: null}
+template: {$eval: 'a == b'}
+result: false
+---
+title: equality of number and boolean
+context: {a: 123, b: true}
+template: {$eval: 'a == b'}
+result: false
+---
+title: equality of number and object
+context: {a: 123, b: {}}
+template: {$eval: 'a == b'}
+result: false
+---
+title: equality of number and array
+context: {a: 123, b: []}
+template: {$eval: 'a == b'}
+result: false
+---
+title: equality of null and string
+context: {a: null, b: 'def'}
+template: {$eval: 'a == b'}
+result: false
+---
+title: equality of null and number
+context: {a: null, b: 27}
+template: {$eval: 'a == b'}
+result: false
+---
+title: equality of null and null
+context: {a: null, b: null}
+template: {$eval: 'a == b'}
+result: true
+---
+title: equality of null and boolean
+context: {a: null, b: true}
+template: {$eval: 'a == b'}
+result: false
+---
+title: equality of null and object
+context: {a: null, b: {}}
+template: {$eval: 'a == b'}
+result: false
+---
+title: equality of null and array
+context: {a: null, b: []}
+template: {$eval: 'a == b'}
+result: false
+---
+title: equality of boolean and string
+context: {a: true, b: 'def'}
+template: {$eval: 'a == b'}
+result: false
+---
+title: equality of boolean and number
+context: {a: true, b: 27}
+template: {$eval: 'a == b'}
+result: false
+---
+title: equality of boolean and null
+context: {a: true, b: null}
+template: {$eval: 'a == b'}
+result: false
+---
+title: equality of boolean and boolean
+context: {a: true, b: true}
+template: {$eval: 'a == b'}
+result: true
+---
+title: equality of boolean and object
+context: {a: true, b: {}}
+template: {$eval: 'a == b'}
+result: false
+---
+title: equality of boolean and array
+context: {a: true, b: []}
+template: {$eval: 'a == b'}
+result: false
+---
+title: equality of object and string
+context: {a: {}, b: 'def'}
+template: {$eval: 'a == b'}
+result: false
+---
+title: equality of object and number
+context: {a: {}, b: 27}
+template: {$eval: 'a == b'}
+result: false
+---
+title: equality of object and null
+context: {a: {}, b: null}
+template: {$eval: 'a == b'}
+result: false
+---
+title: equality of object and boolean
+context: {a: {}, b: true}
+template: {$eval: 'a == b'}
+result: false
+---
+title: equality of object and object
+context: {a: {}, b: {}}
+template: {$eval: 'a == b'}
+result: true
+todo: 'https://github.com/taskcluster/json-e/issues/72'
+---
+title: equality of object and array
+context: {a: {}, b: []}
+template: {$eval: 'a == b'}
+result: false
+---
+title: equality of array and string
+context: {a: [], b: 'def'}
+template: {$eval: 'a == b'}
+result: false
+---
+title: equality of array and number
+context: {a: [], b: 27}
+template: {$eval: 'a == b'}
+result: false
+---
+title: equality of array and null
+context: {a: [], b: null}
+template: {$eval: 'a == b'}
+result: false
+---
+title: equality of array and boolean
+context: {a: [], b: true}
+template: {$eval: 'a == b'}
+result: false
+---
+title: equality of array and object
+context: {a: [], b: {}}
+template: {$eval: 'a == b'}
+result: false
+---
+title: equality of array and array
+context: {a: [], b: []}
+template: {$eval: 'a == b'}
+result: true
+todo: 'https://github.com/taskcluster/json-e/issues/72'
 ################################################################################
 ---
 section: expression language - compound literals

--- a/specification.yml
+++ b/specification.yml
@@ -1131,6 +1131,16 @@ context:  {}
 template: {$eval: '0xff'}
 error: true
 ---
+title:    string literal with single quote
+context:  {}
+template: {$eval: "'three!'"}
+result: 'three!'
+---
+title:    string literal with double quote
+context:  {}
+template: {$eval: '"three!"'}
+result: 'three!'
+---
 title:    leading zeroes (not octal)
 context:  {}
 template: {$eval: '0777'}

--- a/specification.yml
+++ b/specification.yml
@@ -1268,6 +1268,18 @@ title: 'string slicing type error (2)'
 context: {key: '12345'}
 template: {$eval: 'key[:"a"]'}
 error: true
+---
+title: 'string length attribute'
+context: {key: '12345'}
+template: {$eval: 'key.length'}
+result: 5
+todo: 'https://github.com/taskcluster/json-e/issues/63'
+---
+title: 'other string attributes are not set'
+context: {key: 'abc'}
+template: {$eval: 'key.toUpperCase()'}
+error: true
+todo: 'https://github.com/taskcluster/json-e/issues/63'
 ################################################################################
 ---
 section: expression language - property access
@@ -1359,6 +1371,16 @@ title: 'nested, with arithmetic, in property access by string'
 context: {key: {key2: {key3: [1,2,3,4,5]}}}
 template: {$eval: 'key["key2"]["key3"][0] + key["key2"]["key3"][1] + key["key2"]["key3"][2] + key["key2"]["key3"][3] + key["key2"]["key3"][4]'}
 result: 15
+---
+title: 'array length'
+context: {key: [1, 3, 5]}
+template: {$eval: 'key.length'}
+result: 3
+---
+title: 'other array attributes are not available'
+context: {key: [5, 3, 1]}
+template: {$eval: 'key.sort'}
+error: true
 ################################################################################
 ---
 section: expression language - array slicing

--- a/specification.yml
+++ b/specification.yml
@@ -1232,7 +1232,7 @@ template: {$eval: 'max(a, 3)'}
 result: 3
 ################################################################################
 ---
-section: expression language - arithemtic
+section: expression language - arithmetic
 ---
 title: 'addition'
 context: {a: 1, b: 2}
@@ -1304,29 +1304,941 @@ context: {a: 2, b: 3}
 template: {$eval: '2 ** 2 ** 3'}
 result: 256
 ---
-title: 'TypeError: exponentiation (1)'
-context: {a: 'hello', b: 2}
+title: 'unary negation'
+context: {a: 2}
+template: {$eval: '-a'}
+result: -2
+---
+title: 'unary plus'
+context: {a: 2}
+template: {$eval: '+a'}
+result: 2
+################################################################################
+---
+section: expression language - operator type errors
+---
+title: 'addition of strings to numbers'
+context: {a: 'a', b: 1}
+template: {$eval: 'a + b'}
+error: true
+---
+title: 'addition of strings to null'
+context: {a: 'a', b: null}
+template: {$eval: 'a + b'}
+error: true
+---
+title: 'addition of strings to booleans'
+context: {a: 'a', b: true}
+template: {$eval: 'a + b'}
+error: true
+---
+title: 'addition of strings to objects'
+context: {a: 'a', b: {x: 1}}
+template: {$eval: 'a + b'}
+error: true
+---
+title: 'addition of strings to arrays'
+context: {a: 'a', b: [1, 2]}
+template: {$eval: 'a + b'}
+error: true
+---
+title: 'subtraction of strings from strings'
+context: {a: 'a', b: 'b'}
+template: {$eval: 'a-b'}
+error: true
+---
+title: 'subtraction of strings from numbers'
+context: {a: 'a', b: 1}
+template: {$eval: 'a - b'}
+error: true
+---
+title: 'subtraction of strings from null'
+context: {a: 'a', b: null}
+template: {$eval: 'a - b'}
+error: true
+---
+title: 'subtraction of strings from booleans'
+context: {a: 'a', b: true}
+template: {$eval: 'a - b'}
+error: true
+---
+title: 'subtraction of strings from objects'
+context: {a: 'a', b: {x: 1}}
+template: {$eval: 'a - b'}
+error: true
+---
+title: 'subtraction of strings from arrays'
+context: {a: 'a', b: [1, 2]}
+template: {$eval: 'a - b'}
+error: true
+---
+title: 'multiplication of strings to strings'
+context: {a: 'a', b: 'b'}
+template: {$eval: 'a * b'}
+error: true
+---
+title: 'multiplication of strings to numbers'
+context: {a: 'a', b: 1}
+template: {$eval: 'a * b'}
+error: true
+---
+title: 'multiplication of strings to null'
+context: {a: 'a', b: null}
+template: {$eval: 'a * b'}
+error: true
+---
+title: 'multiplication of strings to booleans'
+context: {a: 'a', b: true}
+template: {$eval: 'a * b'}
+error: true
+---
+title: 'multiplication of strings to objects'
+context: {a: 'a', b: {x: 1}}
+template: {$eval: 'a * b'}
+error: true
+---
+title: 'multiplication of strings to arrays'
+context: {a: 'a', b: [1, 2]}
+template: {$eval: 'a * b'}
+error: true
+---
+title: 'division of strings by strings'
+context: {a: 'a', b: 'b'}
+template: {$eval: 'a / b'}
+error: true
+---
+title: 'division of strings by numbers'
+context: {a: 'a', b: 1}
+template: {$eval: 'a / b'}
+error: true
+---
+title: 'division of strings by null'
+context: {a: 'a', b: null}
+template: {$eval: 'a / b'}
+error: true
+---
+title: 'division of strings by booleans'
+context: {a: 'a', b: true}
+template: {$eval: 'a / b'}
+error: true
+---
+title: 'division of strings by objects'
+context: {a: 'a', b: {x: 1}}
+template: {$eval: 'a / b'}
+error: true
+---
+title: 'division of strings by arrays'
+context: {a: 'a', b: [1, 2]}
+template: {$eval: 'a / b'}
+error: true
+---
+title: 'exponentiation of strings by strings'
+context: {a: 'a', b: 'b'}
 template: {$eval: 'a ** b'}
 error: true
 ---
-title: 'TypeError: exponentiation (2)'
-context: {a: 'hello', b: 2}
-template: {$eval: 'b ** a'}
+title: 'exponentiation of strings by numbers'
+context: {a: 'a', b: 1}
+template: {$eval: 'a ** b'}
 error: true
 ---
-title: 'TypeError: exponentiation (3)'
-context: {a: 'hello', b: 2}
-template: {$eval: '"hello" ** b'}
+title: 'exponentiation of strings by null'
+context: {a: 'a', b: null}
+template: {$eval: 'a ** b'}
 error: true
 ---
-title: 'TypeError: exponentiation (4)'
-context: {a: 'hello', b: 2}
-template: {$eval: 'b ** "hello"'}
+title: 'exponentiation of strings by booleans'
+context: {a: 'a', b: true}
+template: {$eval: 'a ** b'}
 error: true
 ---
-title: 'TypeError: exponentiation (5)'
-context: {a: 'hello', b: 2}
-template: {$eval: '2 ** "hello"'}
+title: 'exponentiation of strings by objects'
+context: {a: 'a', b: {x: 1}}
+template: {$eval: 'a ** b'}
+error: true
+---
+title: 'exponentiation of strings by arrays'
+context: {a: 'a', b: [1, 2]}
+template: {$eval: 'a ** b'}
+error: true
+---
+title: 'unary negation of string'
+context: {a: 'a'}
+template: {$eval: '-a'}
+error: true
+---
+title: 'unary plus of string'
+context: {a: 'a'}
+template: {$eval: '+a'}
+error: true
+---
+title: 'addition of numbers to strings'
+context: {a: 13, b: 'b'}
+template: {$eval: 'a + b'}
+error: true
+---
+title: 'addition of numbers to null'
+context: {a: 13, b: null}
+template: {$eval: 'a + b'}
+error: true
+---
+title: 'addition of numbers to booleans'
+context: {a: 13, b: true}
+template: {$eval: 'a + b'}
+error: true
+---
+title: 'addition of numbers to objects'
+context: {a: 13, b: {x: 1}}
+template: {$eval: 'a + b'}
+error: true
+---
+title: 'addition of numbers to arrays'
+context: {a: 13, b: [1, 2]}
+template: {$eval: 'a + b'}
+error: true
+---
+title: 'subtraction of numbers from strings'
+context: {a: 13, b: 'b'}
+template: {$eval: 'a-b'}
+error: true
+---
+title: 'subtraction of numbers from null'
+context: {a: 13, b: null}
+template: {$eval: 'a - b'}
+error: true
+---
+title: 'subtraction of numbers from booleans'
+context: {a: 13, b: true}
+template: {$eval: 'a - b'}
+error: true
+---
+title: 'subtraction of numbers from objects'
+context: {a: 13, b: {x: 1}}
+template: {$eval: 'a - b'}
+error: true
+---
+title: 'subtraction of numbers from arrays'
+context: {a: 13, b: [1, 2]}
+template: {$eval: 'a - b'}
+error: true
+---
+title: 'multiplication of numbers to strings'
+context: {a: 13, b: 'b'}
+template: {$eval: 'a * b'}
+error: true
+---
+title: 'multiplication of numbers to null'
+context: {a: 13, b: null}
+template: {$eval: 'a * b'}
+error: true
+---
+title: 'multiplication of numbers to booleans'
+context: {a: 13, b: true}
+template: {$eval: 'a * b'}
+error: true
+---
+title: 'multiplication of numbers to objects'
+context: {a: 13, b: {x: 1}}
+template: {$eval: 'a * b'}
+error: true
+---
+title: 'multiplication of numbers to arrays'
+context: {a: 13, b: [1, 2]}
+template: {$eval: 'a / b'}
+error: true
+---
+title: 'division of numbers by strings'
+context: {a: 13, b: 'b'}
+template: {$eval: 'a / b'}
+error: true
+---
+title: 'division of numbers by null'
+context: {a: 13, b: null}
+template: {$eval: 'a / b'}
+error: true
+---
+title: 'division of numbers by booleans'
+context: {a: 13, b: true}
+template: {$eval: 'a / b'}
+error: true
+---
+title: 'division of numbers by objects'
+context: {a: 13, b: {x: 1}}
+template: {$eval: 'a / b'}
+error: true
+---
+title: 'division of numbers by arrays'
+context: {a: 13, b: [1, 2]}
+template: {$eval: 'a / b'}
+error: true
+---
+title: 'exponentiation of numbers by strings'
+context: {a: 13, b: 'b'}
+template: {$eval: 'a ** b'}
+error: true
+---
+title: 'exponentiation of numbers by null'
+context: {a: 13, b: null}
+template: {$eval: 'a ** b'}
+error: true
+---
+title: 'exponentiation of numbers by booleans'
+context: {a: 13, b: true}
+template: {$eval: 'a ** b'}
+error: true
+---
+title: 'exponentiation of numbers by objects'
+context: {a: 13, b: {x: 1}}
+template: {$eval: 'a ** b'}
+error: true
+---
+title: 'exponentiation of numbers by arrays'
+context: {a: 13, b: [1, 2]}
+template: {$eval: 'a ** b'}
+error: true
+---
+title: 'addition of null to strings'
+context: {a: null, b: 'a'}
+template: {$eval: 'a + b'}
+error: true
+---
+title: 'addition of null to numbers'
+context: {a: null, b: 1}
+template: {$eval: 'a + b'}
+error: true
+---
+title: 'addition of null to null'
+context: {a: null, b: null}
+template: {$eval: 'a + b'}
+error: true
+---
+title: 'addition of null to booleans'
+context: {a: null, b: true}
+template: {$eval: 'a + b'}
+error: true
+---
+title: 'addition of null to objects'
+context: {a: null, b: {x: 1}}
+template: {$eval: 'a + b'}
+error: true
+---
+title: 'addition of null to arrays'
+context: {a: null, b: [1, 2]}
+template: {$eval: 'a + b'}
+error: true
+---
+title: 'subtraction of null from strings'
+context: {a: null, b: 'b'}
+template: {$eval: 'a-b'}
+error: true
+---
+title: 'subtraction of null from numbers'
+context: {a: null, b: 1}
+template: {$eval: 'a - b'}
+error: true
+---
+title: 'subtraction of null from null'
+context: {a: null, b: null}
+template: {$eval: 'a - b'}
+error: true
+---
+title: 'subtraction of null from booleans'
+context: {a: null, b: true}
+template: {$eval: 'a - b'}
+error: true
+---
+title: 'subtraction of null from objects'
+context: {a: null, b: {x: 1}}
+template: {$eval: 'a - b'}
+error: true
+---
+title: 'subtraction of null from arrays'
+context: {a: null, b: [1, 2]}
+template: {$eval: 'a - b'}
+error: true
+---
+title: 'multiplication of null to strings'
+context: {a: null, b: 'b'}
+template: {$eval: 'a * b'}
+error: true
+---
+title: 'multiplication of null to numbers'
+context: {a: null, b: 1}
+template: {$eval: 'a * b'}
+error: true
+---
+title: 'multiplication of null to null'
+context: {a: null, b: null}
+template: {$eval: 'a * b'}
+error: true
+---
+title: 'multiplication of null to booleans'
+context: {a: null, b: true}
+template: {$eval: 'a * b'}
+error: true
+---
+title: 'multiplication of null to objects'
+context: {a: null, b: {x: 1}}
+template: {$eval: 'a * b'}
+error: true
+---
+title: 'multiplication of null to arrays'
+context: {a: null, b: [1, 2]}
+template: {$eval: 'a / b'}
+error: true
+---
+title: 'division of null by strings'
+context: {a: null, b: 'b'}
+template: {$eval: 'a / b'}
+error: true
+---
+title: 'division of null by numbers'
+context: {a: null, b: 1}
+template: {$eval: 'a / b'}
+error: true
+---
+title: 'division of null by null'
+context: {a: null, b: null}
+template: {$eval: 'a / b'}
+error: true
+---
+title: 'division of null by booleans'
+context: {a: null, b: true}
+template: {$eval: 'a / b'}
+error: true
+---
+title: 'division of null by objects'
+context: {a: null, b: {x: 1}}
+template: {$eval: 'a / b'}
+error: true
+---
+title: 'division of null by arrays'
+context: {a: null, b: [1, 2]}
+template: {$eval: 'a / b'}
+error: true
+---
+title: 'exponentiation of null by strings'
+context: {a: null, b: 'b'}
+template: {$eval: 'a ** b'}
+error: true
+---
+title: 'exponentiation of null by numbers'
+context: {a: null, b: 1}
+template: {$eval: 'a ** b'}
+error: true
+---
+title: 'exponentiation of null by null'
+context: {a: null, b: null}
+template: {$eval: 'a ** b'}
+error: true
+---
+title: 'exponentiation of null by booleans'
+context: {a: null, b: true}
+template: {$eval: 'a ** b'}
+error: true
+---
+title: 'exponentiation of null by objects'
+context: {a: null, b: {x: 1}}
+template: {$eval: 'a ** b'}
+error: true
+---
+title: 'exponentiation of null by arrays'
+context: {a: null, b: [1, 2]}
+template: {$eval: 'a ** b'}
+error: true
+---
+title: 'unary negation of null'
+context: {a: null}
+template: {$eval: '-a'}
+error: true
+todo: 'https://github.com/taskcluster/json-e/issues/73'
+---
+title: 'unary plus of null'
+context: {a: null}
+template: {$eval: '+a'}
+error: true
+todo: 'https://github.com/taskcluster/json-e/issues/73'
+---
+title: 'addition of boolean to strings'
+context: {a: true, b: 'a'}
+template: {$eval: 'a + b'}
+error: true
+---
+title: 'addition of boolean to numbers'
+context: {a: true, b: 1}
+template: {$eval: 'a + b'}
+error: true
+---
+title: 'addition of boolean to null'
+context: {a: true, b: null}
+template: {$eval: 'a + b'}
+error: true
+---
+title: 'addition of boolean to booleans'
+context: {a: true, b: true}
+template: {$eval: 'a + b'}
+error: true
+---
+title: 'addition of boolean to objects'
+context: {a: true, b: {x: 1}}
+template: {$eval: 'a + b'}
+error: true
+---
+title: 'addition of boolean to arrays'
+context: {a: true, b: [1, 2]}
+template: {$eval: 'a + b'}
+error: true
+---
+title: 'subtraction of boolean from strings'
+context: {a: true, b: 'b'}
+template: {$eval: 'a-b'}
+error: true
+---
+title: 'subtraction of boolean from numbers'
+context: {a: true, b: 1}
+template: {$eval: 'a - b'}
+error: true
+---
+title: 'subtraction of boolean from null'
+context: {a: true, b: null}
+template: {$eval: 'a - b'}
+error: true
+---
+title: 'subtraction of boolean from booleans'
+context: {a: true, b: true}
+template: {$eval: 'a - b'}
+error: true
+---
+title: 'subtraction of boolean from objects'
+context: {a: true, b: {x: 1}}
+template: {$eval: 'a - b'}
+error: true
+---
+title: 'subtraction of boolean from arrays'
+context: {a: true, b: [1, 2]}
+template: {$eval: 'a - b'}
+error: true
+---
+title: 'multiplication of boolean to strings'
+context: {a: true, b: 'b'}
+template: {$eval: 'a * b'}
+error: true
+---
+title: 'multiplication of boolean to numbers'
+context: {a: true, b: 1}
+template: {$eval: 'a * b'}
+error: true
+---
+title: 'multiplication of boolean to null'
+context: {a: true, b: null}
+template: {$eval: 'a * b'}
+error: true
+---
+title: 'multiplication of boolean to booleans'
+context: {a: true, b: true}
+template: {$eval: 'a * b'}
+error: true
+---
+title: 'multiplication of boolean to objects'
+context: {a: true, b: {x: 1}}
+template: {$eval: 'a * b'}
+error: true
+---
+title: 'multiplication of boolean to arrays'
+context: {a: true, b: [1, 2]}
+template: {$eval: 'a / b'}
+error: true
+---
+title: 'division of boolean by strings'
+context: {a: true, b: 'b'}
+template: {$eval: 'a / b'}
+error: true
+---
+title: 'division of boolean by numbers'
+context: {a: true, b: 1}
+template: {$eval: 'a / b'}
+error: true
+---
+title: 'division of boolean by null'
+context: {a: true, b: null}
+template: {$eval: 'a / b'}
+error: true
+---
+title: 'division of boolean by booleans'
+context: {a: true, b: true}
+template: {$eval: 'a / b'}
+error: true
+---
+title: 'division of boolean by objects'
+context: {a: true, b: {x: 1}}
+template: {$eval: 'a / b'}
+error: true
+---
+title: 'division of boolean by arrays'
+context: {a: true, b: [1, 2]}
+template: {$eval: 'a / b'}
+error: true
+---
+title: 'exponentiation of boolean by strings'
+context: {a: true, b: 'b'}
+template: {$eval: 'a ** b'}
+error: true
+---
+title: 'exponentiation of boolean by numbers'
+context: {a: true, b: 1}
+template: {$eval: 'a ** b'}
+error: true
+---
+title: 'exponentiation of boolean by null'
+context: {a: true, b: null}
+template: {$eval: 'a ** b'}
+error: true
+---
+title: 'exponentiation of boolean by booleans'
+context: {a: true, b: true}
+template: {$eval: 'a ** b'}
+error: true
+---
+title: 'exponentiation of boolean by objects'
+context: {a: true, b: {x: 1}}
+template: {$eval: 'a ** b'}
+error: true
+---
+title: 'exponentiation of boolean by arrays'
+context: {a: true, b: [1, 2]}
+template: {$eval: 'a ** b'}
+error: true
+---
+title: 'unary negation of boolean'
+context: {a: true}
+template: {$eval: '-a'}
+error: true
+todo: 'https://github.com/taskcluster/json-e/issues/73'
+---
+title: 'unary plus of boolean'
+context: {a: true}
+template: {$eval: '+a'}
+error: true
+todo: 'https://github.com/taskcluster/json-e/issues/73'
+---
+title: 'addition of object to strings'
+context: {a: {x: 10}, b: 'a'}
+template: {$eval: 'a + b'}
+error: true
+---
+title: 'addition of object to numbers'
+context: {a: {x: 10}, b: 1}
+template: {$eval: 'a + b'}
+error: true
+---
+title: 'addition of object to null'
+context: {a: {x: 10}, b: null}
+template: {$eval: 'a + b'}
+error: true
+---
+title: 'addition of object to booleans'
+context: {a: {x: 10}, b: true}
+template: {$eval: 'a + b'}
+error: true
+---
+title: 'addition of object to objects'
+context: {a: {x: 10}, b: {x: 1}}
+template: {$eval: 'a + b'}
+error: true
+---
+title: 'addition of object to arrays'
+context: {a: {x: 10}, b: [1, 2]}
+template: {$eval: 'a + b'}
+error: true
+---
+title: 'subtraction of object from strings'
+context: {a: {x: 10}, b: 'b'}
+template: {$eval: 'a-b'}
+error: true
+---
+title: 'subtraction of object from numbers'
+context: {a: {x: 10}, b: 1}
+template: {$eval: 'a - b'}
+error: true
+---
+title: 'subtraction of object from null'
+context: {a: {x: 10}, b: null}
+template: {$eval: 'a - b'}
+error: true
+---
+title: 'subtraction of object from booleans'
+context: {a: {x: 10}, b: true}
+template: {$eval: 'a - b'}
+error: true
+---
+title: 'subtraction of object from objects'
+context: {a: {x: 10}, b: {x: 1}}
+template: {$eval: 'a - b'}
+error: true
+---
+title: 'subtraction of object from arrays'
+context: {a: {x: 10}, b: [1, 2]}
+template: {$eval: 'a - b'}
+error: true
+---
+title: 'multiplication of object to strings'
+context: {a: {x: 10}, b: 'b'}
+template: {$eval: 'a * b'}
+error: true
+---
+title: 'multiplication of object to numbers'
+context: {a: {x: 10}, b: 1}
+template: {$eval: 'a * b'}
+error: true
+---
+title: 'multiplication of object to null'
+context: {a: {x: 10}, b: null}
+template: {$eval: 'a * b'}
+error: true
+---
+title: 'multiplication of object to booleans'
+context: {a: {x: 10}, b: true}
+template: {$eval: 'a * b'}
+error: true
+---
+title: 'multiplication of object to objects'
+context: {a: {x: 10}, b: {x: 1}}
+template: {$eval: 'a * b'}
+error: true
+---
+title: 'multiplication of object to arrays'
+context: {a: {x: 10}, b: [1, 2]}
+template: {$eval: 'a / b'}
+error: true
+---
+title: 'division of object by strings'
+context: {a: {x: 10}, b: 'b'}
+template: {$eval: 'a / b'}
+error: true
+---
+title: 'division of object by numbers'
+context: {a: {x: 10}, b: 1}
+template: {$eval: 'a / b'}
+error: true
+---
+title: 'division of object by null'
+context: {a: {x: 10}, b: null}
+template: {$eval: 'a / b'}
+error: true
+---
+title: 'division of object by booleans'
+context: {a: {x: 10}, b: true}
+template: {$eval: 'a / b'}
+error: true
+---
+title: 'division of object by objects'
+context: {a: {x: 10}, b: {x: 1}}
+template: {$eval: 'a / b'}
+error: true
+---
+title: 'division of object by arrays'
+context: {a: {x: 10}, b: [1, 2]}
+template: {$eval: 'a / b'}
+error: true
+---
+title: 'exponentiation of object by strings'
+context: {a: {x: 10}, b: 'b'}
+template: {$eval: 'a ** b'}
+error: true
+---
+title: 'exponentiation of object by numbers'
+context: {a: {x: 10}, b: 1}
+template: {$eval: 'a ** b'}
+error: true
+---
+title: 'exponentiation of object by null'
+context: {a: {x: 10}, b: null}
+template: {$eval: 'a ** b'}
+error: true
+---
+title: 'exponentiation of object by booleans'
+context: {a: {x: 10}, b: true}
+template: {$eval: 'a ** b'}
+error: true
+---
+title: 'exponentiation of object by objects'
+context: {a: {x: 10}, b: {x: 1}}
+template: {$eval: 'a ** b'}
+error: true
+---
+title: 'exponentiation of object by arrays'
+context: {a: {x: 10}, b: [1, 2]}
+template: {$eval: 'a ** b'}
+error: true
+---
+title: 'unary negation of object'
+context: {a: {x: 10}}
+template: {$eval: '-a'}
+error: true
+---
+title: 'unary plus of object'
+context: {a: {x: 10}}
+template: {$eval: '+a'}
+error: true
+---
+title: 'addition of array to strings'
+context: {a: [1, 2], b: 'a'}
+template: {$eval: 'a + b'}
+error: true
+---
+title: 'addition of array to numbers'
+context: {a: [1, 2], b: 1}
+template: {$eval: 'a + b'}
+error: true
+---
+title: 'addition of array to null'
+context: {a: [1, 2], b: null}
+template: {$eval: 'a + b'}
+error: true
+---
+title: 'addition of array to booleans'
+context: {a: [1, 2], b: true}
+template: {$eval: 'a + b'}
+error: true
+---
+title: 'addition of array to objects'
+context: {a: [1, 2], b: {x: 1}}
+template: {$eval: 'a + b'}
+error: true
+---
+title: 'addition of array to arrays'
+context: {a: [1, 2], b: [1, 2]}
+template: {$eval: 'a + b'}
+error: true
+---
+title: 'subtraction of array from strings'
+context: {a: [1, 2], b: 'b'}
+template: {$eval: 'a-b'}
+error: true
+---
+title: 'subtraction of array from numbers'
+context: {a: [1, 2], b: 1}
+template: {$eval: 'a - b'}
+error: true
+---
+title: 'subtraction of array from null'
+context: {a: [1, 2], b: null}
+template: {$eval: 'a - b'}
+error: true
+---
+title: 'subtraction of array from booleans'
+context: {a: [1, 2], b: true}
+template: {$eval: 'a - b'}
+error: true
+---
+title: 'subtraction of array from objects'
+context: {a: [1, 2], b: {x: 1}}
+template: {$eval: 'a - b'}
+error: true
+---
+title: 'subtraction of array from arrays'
+context: {a: [1, 2], b: [1, 2]}
+template: {$eval: 'a - b'}
+error: true
+---
+title: 'multiplication of array to strings'
+context: {a: [1, 2], b: 'b'}
+template: {$eval: 'a * b'}
+error: true
+---
+title: 'multiplication of array to numbers'
+context: {a: [1, 2], b: 1}
+template: {$eval: 'a * b'}
+error: true
+---
+title: 'multiplication of array to null'
+context: {a: [1, 2], b: null}
+template: {$eval: 'a * b'}
+error: true
+---
+title: 'multiplication of array to booleans'
+context: {a: [1, 2], b: true}
+template: {$eval: 'a * b'}
+error: true
+---
+title: 'multiplication of array to objects'
+context: {a: [1, 2], b: {x: 1}}
+template: {$eval: 'a * b'}
+error: true
+---
+title: 'multiplication of array to arrays'
+context: {a: [1, 2], b: [1, 2]}
+template: {$eval: 'a / b'}
+error: true
+---
+title: 'division of array by strings'
+context: {a: [1, 2], b: 'b'}
+template: {$eval: 'a / b'}
+error: true
+---
+title: 'division of array by numbers'
+context: {a: [1, 2], b: 1}
+template: {$eval: 'a / b'}
+error: true
+---
+title: 'division of array by null'
+context: {a: [1, 2], b: null}
+template: {$eval: 'a / b'}
+error: true
+---
+title: 'division of array by booleans'
+context: {a: [1, 2], b: true}
+template: {$eval: 'a / b'}
+error: true
+---
+title: 'division of array by objects'
+context: {a: [1, 2], b: {x: 1}}
+template: {$eval: 'a / b'}
+error: true
+---
+title: 'division of array by arrays'
+context: {a: [1, 2], b: [1, 2]}
+template: {$eval: 'a / b'}
+error: true
+---
+title: 'exponentiation of array by strings'
+context: {a: [1, 2], b: 'b'}
+template: {$eval: 'a ** b'}
+error: true
+---
+title: 'exponentiation of array by numbers'
+context: {a: [1, 2], b: 1}
+template: {$eval: 'a ** b'}
+error: true
+---
+title: 'exponentiation of array by null'
+context: {a: [1, 2], b: null}
+template: {$eval: 'a ** b'}
+error: true
+---
+title: 'exponentiation of array by booleans'
+context: {a: [1, 2], b: true}
+template: {$eval: 'a ** b'}
+error: true
+---
+title: 'exponentiation of array by objects'
+context: {a: [1, 2], b: {x: 1}}
+template: {$eval: 'a ** b'}
+error: true
+---
+title: 'exponentiation of array by arrays'
+context: {a: [1, 2], b: [1, 2]}
+template: {$eval: 'a ** b'}
+error: true
+---
+title: 'unary negation of array'
+context: {a: [1, 2]}
+template: {$eval: '-a'}
+error: true
+---
+title: 'unary plus of array'
+context: {a: [1, 2]}
+template: {$eval: '+a'}
 error: true
 ################################################################################
 ---

--- a/specification.yml
+++ b/specification.yml
@@ -1126,6 +1126,16 @@ context:  {}
 template: {$eval: '10.5'}
 result:   10.5
 ---
+title:    hex literal
+context:  {}
+template: {$eval: '0xff'}
+error: true
+---
+title:    leading zeroes (not octal)
+context:  {}
+template: {$eval: '0777'}
+result: 777
+---
 title:    addition
 context:  {a: 1, b: 2}
 template: {$eval: 'a + b + 7'}

--- a/specification.yml
+++ b/specification.yml
@@ -474,29 +474,101 @@ context:  {}
 template: {$sort: [3, 4, 1, 2]}
 result:   [1, 2, 3, 4]
 ---
+title:    simple sort of strings (shortest first)
+context:  {}
+template: {$sort: ['android', 'aardvark', 'add', 'adderall']}
+result:   ['aardvark', 'add', 'adderall', 'android']
+---
+title:    simple sort of multi-digit numbers
+context:  {}
+template: {$sort: [111, 22, 3]}
+result:   [3, 22, 111]
+todo: 'https://github.com/taskcluster/json-e/issues/71'
+---
 title:    simple sort with $eval
 context:  {array: [3, 4, 1, 2]}
 template: {$sort: {$eval: 'array'}}
 result:   [1, 2, 3, 4]
 ---
-title:    sort by
+title:    sort by, returning number
 context:  {}
 template:
-  $sort: [{a: 2}, {a: 1, b: []}, {a: 3}]
+  $sort: [{a: 20}, {a: 10, b: []}, {a: 3}]
   by(x): 'x.a'
-result:   [{a: 1, b: []}, {a: 2}, {a: 3}]
+result:   [{a: 3}, {a: 10, b: []}, {a: 20}]
+todo: 'https://github.com/taskcluster/json-e/issues/71'
+---
+title:    sort by, returning string
+context:  {}
+template:
+  $sort: [{s: 'android'}, {s: 'add'}, {s: 'adderall'}]
+  by(x): 'x.s'
+result: [{s: 'add'}, {s: 'adderall'}, {s: 'android'}]
+todo: 'https://github.com/taskcluster/json-e/issues/71'
 ---
 title:    cannot sort objects without by
 context:  {}
 template:
   $sort: [{a: 2}, {a: 1, b: []}, {a: 3}]
-error: true  # list of objects must have a 'by(x)' property
+error: true
+---
+title:    by cannot return objects
+context:  {}
+template:
+  $sort: [{a: 2}, {a: 1, b: []}, {a: 3}]
+  by(x): x
+error: true
+todo: 'https://github.com/taskcluster/json-e/issues/71'
 ---
 title:    cannot sort arrays without by
 context:  {}
 template:
   $sort: [[1,2,3], [4,5], [], [8,9,10]]
-error: true  # list of arrays must have a 'by(x)' property
+error: true
+---
+title:    by cannot return arrays
+context:  {}
+template:
+  $sort: [[1,2,3], [4,5], [], [8,9,10]]
+  by(x): x
+error: true
+todo: 'https://github.com/taskcluster/json-e/issues/71'
+---
+title:    cannot sort nulls
+context:  {}
+template: {$sort: [null, null]}
+error: true
+todo: 'https://github.com/taskcluster/json-e/issues/71'
+---
+title:    cannot sort nulls, even with by
+context:  {}
+template: {$sort: [null, null], 'by(x)': 'x'}
+error: true
+todo: 'https://github.com/taskcluster/json-e/issues/71'
+---
+title:    cannot sort booleans
+context:  {}
+template: {$sort: [false, true]}
+error: true
+todo: 'https://github.com/taskcluster/json-e/issues/71'
+---
+title:    cannot sort booleans, even with by
+context:  {}
+template: {$sort: [false, true], 'by(x)': 'x'}
+error: true
+todo: 'https://github.com/taskcluster/json-e/issues/71'
+---
+title:    cannot sort numbers and strings together
+context:  {}
+template: {$sort: [1, 'a']}
+error: true
+todo: 'https://github.com/taskcluster/json-e/issues/71'
+---
+title:    cannot sort numbers and strings together even with by
+context:  {}
+template: {$sort: [1, 'a'], 'by(x)': 'x'}
+error: true
+todo: 'https://github.com/taskcluster/json-e/issues/71'
 ---
 title:    sort requires an array (string)
 context:  {}
@@ -514,6 +586,12 @@ title:    sort requires an array (object)
 context:  {}
 template:
   $sort:  {k: 1, b: 4, x: 8}
+error: true  # $sort must be given an array
+---
+title:    sort requires an array (null)
+context:  {}
+template:
+  $sort:  null
 error: true  # $sort must be given an array
 ################################################################################
 ---

--- a/specification.yml
+++ b/specification.yml
@@ -1188,6 +1188,17 @@ context:  {}
 template: {$eval: '"three!"'}
 result: 'three!'
 ---
+title:    boolean literals
+context:  {}
+template: {$eval: '[true, false]'}
+result: [true, false]
+---
+title:    null literal
+context:  {}
+template: {$eval: '[null, null]'}
+result: [null, null]
+todo: 'https://github.com/taskcluster/json-e/issues/74'
+---
 title:    leading zeroes (not octal)
 context:  {}
 template: {$eval: '0777'}

--- a/specification.yml
+++ b/specification.yml
@@ -213,6 +213,58 @@ title: $if->else, else => object, interpolation, false
 context: {cond: false, key: 'world'}
 template: {$if: 'cond', else: {key: 'hello ${key}'}}
 result: {key: 'hello world'}
+---
+title: $if->then->else, empty string
+context: {cond: "", key: 'world'}
+template: {$if: 'cond', then: "t", else: "f"}
+result: f
+---
+title: $if->then->else, nonempty string
+context: {cond: "stuff", key: 'world'}
+template: {$if: 'cond', then: "t", else: "f"}
+result: t
+---
+title: $if->then->else, string "0"  # once upon a time, this was false in PHP.. maybe still is
+context: {cond: "0", key: 'world'}
+template: {$if: 'cond', then: "t", else: "f"}
+result: t
+---
+title: $if->then->else, zero
+context: {cond: 0, key: 'world'}
+template: {$if: 'cond', then: "t", else: "f"}
+result: f
+---
+title: $if->then->else, one
+context: {cond: 1, key: 'world'}
+template: {$if: 'cond', then: "t", else: "f"}
+result: t
+---
+title: $if->then->else, null
+context: {cond: null, key: 'world'}
+template: {$if: 'cond', then: "t", else: "f"}
+result: f
+---
+title: $if->then->else, empty array
+context: {cond: [], key: 'world'}
+template: {$if: 'cond', then: "t", else: "f"}
+result: f
+todo: 'https://github.com/taskcluster/json-e/issues/68'
+---
+title: $if->then->else, nonempty array
+context: {cond: [1, 2], key: 'world'}
+template: {$if: 'cond', then: "t", else: "f"}
+result: t
+---
+title: $if->then->else, empty object
+context: {cond: {}, key: 'world'}
+template: {$if: 'cond', then: "t", else: "f"}
+result: f
+todo: 'https://github.com/taskcluster/json-e/issues/68'
+---
+title: $if->then->else, nonempty object
+context: {cond: {a: 2}, key: 'world'}
+template: {$if: 'cond', then: "t", else: "f"}
+result: t
 ################################################################################
 ---
 section:  fromNow

--- a/specification.yml
+++ b/specification.yml
@@ -1324,6 +1324,11 @@ title: 'nested property access with numeric value'
 context: {key: {key2: {key3: 1}}}
 template: {$eval: 'key["key2"]["key3"]'}
 result: 1
+---
+title: 'property access with expression value'
+context: {key: abc, values: {abc: 2, def: 3}}
+template: {$eval: 'values[key]'}
+result: 2
 ################################################################################
 ---
 section: expression language - array access

--- a/specification.yml
+++ b/specification.yml
@@ -265,6 +265,12 @@ title: $if->then->else, nonempty object
 context: {cond: {a: 2}, key: 'world'}
 template: {$if: 'cond', then: "t", else: "f"}
 result: t
+---
+title: $if->then evaluating to nothing at the top level is an error
+context: {cond: false}
+template: {$if: 'cond', then: "t"}
+error: true
+todo: 'https://github.com/taskcluster/json-e/issues/69'
 ################################################################################
 ---
 section:  fromNow
@@ -432,10 +438,31 @@ template:
     then: {$eval: 'y.k'}
 result: [1, 3]
 ---
-title:    $map requires an array
+title:    $map requires an array, not object
 context:  {}
 template:
   $map: {a: 1, b: 2, c: 3}
+  each(y): {$eval: 'y.k'}
+error: true # can't do map on non-arrays
+---
+title:    $map requires an array, not string
+context:  {}
+template:
+  $map: "a, b, c"
+  each(y): {$eval: 'y.k'}
+error: true # can't do map on non-arrays
+---
+title:    $map requires an array, not number
+context:  {}
+template:
+  $map: 10.1
+  each(y): {$eval: 'y.k'}
+error: true # can't do map on non-arrays
+---
+title:    $map requires an array, not null
+context:  {}
+template:
+  $map: null
   each(y): {$eval: 'y.k'}
 error: true # can't do map on non-arrays
 ################################################################################

--- a/specification.yml
+++ b/specification.yml
@@ -884,6 +884,11 @@ result: 'hello world!'
 ---
 section:  expression language - basics
 ---
+title:    decimal literal
+context:  {}
+template: {$eval: '10.5'}
+result:   10.5
+---
 title:    addition
 context:  {a: 1, b: 2}
 template: {$eval: 'a + b + 7'}

--- a/specification.yml
+++ b/specification.yml
@@ -1229,6 +1229,11 @@ context: {}
 template: {$eval: '"12345"[-2]'}
 result: '4'
 ---
+title: 'string indexing (noninteger)'
+context: {}
+template: {$eval: '"12345"[2.5]'}
+todo: 'https://github.com/taskcluster/json-e/issues/64'
+---
 title: 'string slicing (1)'
 context: {key: '12345'}
 template: {$eval: 'key[1:-1]'}
@@ -1238,6 +1243,21 @@ title: 'string slicing (2)'
 context: {key: '12345'}
 template: {$eval: 'key[-2:]'}
 result: '45'
+---
+title: 'string slicing (noninteger first index)'
+context: {key: '12345'}
+template: {$eval: 'key[1.5:3]'}
+todo: 'https://github.com/taskcluster/json-e/issues/64'
+---
+title: 'string slicing (noninteger second index)'
+context: {key: '12345'}
+template: {$eval: 'key[1:3.5]'}
+todo: 'https://github.com/taskcluster/json-e/issues/64'
+---
+title: 'string slicing (noninteger indexes)'
+context: {key: '12345'}
+template: {$eval: 'key[1.5:3.5]'}
+todo: 'https://github.com/taskcluster/json-e/issues/64'
 ---
 title: 'string slicing type error (1)'
 context: {key: '12345'}
@@ -1294,6 +1314,11 @@ title: 'numeric, nonzero index'
 context: {key: [1,2,3,4,5]}
 template: {$eval: 'key[2]'}
 result: 3
+---
+title: 'numeric, noninteger index'
+context: {key: [1,2,3,4,5]}
+template: {$eval: 'key[2.5]'}
+todo: 'https://github.com/taskcluster/json-e/issues/64'
 ---
 title: 'arithemtic with results'
 context: {key: [1,2,3,4,5]}
@@ -1353,10 +1378,20 @@ context: {key: [1,2,3,4,5]}
 template: {$eval: 'key[-5:-1]'}
 result: [1,2,3,4]
 ---
-title: 'array slicing (noninteger index)'
+title: 'array slicing (noninteger first index)'
 context: {key: [1,2,3,4,5]}
-template: {$eval: 'key[key.length / 2: key.length]'}
-result: [3,4,5]
+template: {$eval: 'key[2.5: 4]'}
+todo: 'https://github.com/taskcluster/json-e/issues/64'
+---
+title: 'array slicing (noninteger last index)'
+context: {key: [1,2,3,4,5]}
+template: {$eval: 'key[2: 3.5]'}
+todo: 'https://github.com/taskcluster/json-e/issues/64'
+---
+title: 'array slicing (noninteger indexes)'
+context: {key: [1,2,3,4,5]}
+template: {$eval: 'key[2.5: 3.5]'}
+todo: 'https://github.com/taskcluster/json-e/issues/64'
 ---
 title: 'array slicing (no end index)'
 context: {key: [1,2,3,4,5]}

--- a/specification.yml
+++ b/specification.yml
@@ -2871,6 +2871,26 @@ title: 'property access with expression value'
 context: {key: abc, values: {abc: 2, def: 3}}
 template: {$eval: 'values[key]'}
 result: 2
+---
+title: 'property of number'
+context: {key: 123}
+template: {$eval: 'key.valueOf'}
+error: true
+---
+title: 'property of null'
+context: {key: null}
+template: {$eval: 'key.foo'}
+error: true
+---
+title: 'property of boolean'
+context: {key: null}
+template: {$eval: 'key.valueOf'}
+error: true
+---
+title: 'property of array'
+context: {key: []}
+template: {$eval: 'key.valueOf'}
+error: true
 ################################################################################
 ---
 section: expression language - array access

--- a/specification.yml
+++ b/specification.yml
@@ -1367,6 +1367,21 @@ context: {key: {a: 1}}
 template: {$eval: 'key'}
 result: {a: 1}
 ---
+title: 'property with null value'
+context: {key: null}
+template: {$eval: 'key'}
+result: null
+---
+title: 'missing property'
+context: {key: {a: 1}}
+template: {$eval: 'key.b'}
+error: true
+---
+title: 'missing property by name'
+context: {key: {a: 1}}
+template: {$eval: 'key["b"]'}
+error: true
+---
 title: 'nested property access with object value'
 context: {key: {key2: {key3: {a: 1}}}}
 template: {$eval: 'key.key2.key3'}

--- a/specification.yml
+++ b/specification.yml
@@ -83,12 +83,28 @@ result:   {message: 'hello##world'}
 title:    can't interpolate arrays
 context:  {key: [1,2,3]}
 template: {message: 'hello ${key}'}
-error:    true #TODO: Decide if it should be interpolated as JSON
+error:    true
 ---
 title:    can't interpolate objects
 context:  {key: {}}
 template: 'hello ${key}'
-error:    true #TODO: Decide if it should be interpolated as JSON
+error:    true
+---
+title:    booleans interpolate
+context:  {t: true, f: false}
+template: '${t} or ${f}: yeast is a bacterium'
+result:   'true or false: yeast is a bacterium'
+---
+title:    numbers interpolate
+context:  {round: 3, decimal: 3.75}
+template: '${round}, really ${decimal}'
+result:   '3, really 3.75'
+---
+title:    nulls interpolate
+context:  {nothing: null}
+template: 'big pile of ${nothing}'
+result:   'big pile of null'
+todo:     'https://github.com/taskcluster/json-e/issues/65'
 ---
 title: invalid context (2)
 context: {'a b c': 1}

--- a/specification.yml
+++ b/specification.yml
@@ -10,12 +10,7 @@
 # {section: '...'} is encouraged to separate sections.
 #
 # Test conditions:
-#   1) Context is assumed to always functions:
-#     - max(a, b)
-#     - min(a, b)
-#   2) Time at test time is expected to be '2017-01-19T16:27:20.974Z'
-#   3) JSON is rendered to strings without whitespace and preserving order of
-#      keys
+#   1) Time at test time is expected to be '2017-01-19T16:27:20.974Z'
 ################################################################################
 ---
 section:  Initial Minimal Subset
@@ -698,6 +693,12 @@ context: {key1: 1, key2: 2}
 template: {$eval: 'min(2, 1, 3, 4, 5)'}
 result: 1
 ---
+title: min (7)
+context: {}
+template: {$eval: 'min()'}
+error: true
+todo: 'https://github.com/taskcluster/json-e/issues/75'
+---
 title: max (1)
 context: {key1: 1, key2: 2}
 template: {$eval: 'max(key1, key2)'}
@@ -727,6 +728,12 @@ title: max (6)
 context: {key1: 1, key2: 2}
 template: {$eval: 'max(2, 1, 3, 4, 5)'}
 result: 5
+---
+title: max (7)
+context: {}
+template: {$eval: 'max()'}
+error: true
+todo: 'https://github.com/taskcluster/json-e/issues/75'
 ---
 title: sqrt (1)
 context: {key: 4}

--- a/specification.yml
+++ b/specification.yml
@@ -2324,7 +2324,7 @@ result: true
 ---
 title: 'or operator (1)'
 context: {tt: true, ff: false}
-template: {$eval: 'tt || ff'}
+template: {$eval: 'tt || tt'}
 result: true
 ---
 title: 'or operator (2)'

--- a/specification.yml
+++ b/specification.yml
@@ -2782,17 +2782,17 @@ context: {key: '12345'}
 template: {$eval: 'key[-2:]'}
 result: '45'
 ---
-title: 'string slicing (noninteger first index)'
+title: 'string slicing (fractional first index)'
 context: {key: '12345'}
 template: {$eval: 'key[1.5:3]'}
 todo: 'https://github.com/taskcluster/json-e/issues/64'
 ---
-title: 'string slicing (noninteger second index)'
+title: 'string slicing (fractional second index)'
 context: {key: '12345'}
 template: {$eval: 'key[1:3.5]'}
 todo: 'https://github.com/taskcluster/json-e/issues/64'
 ---
-title: 'string slicing (noninteger indexes)'
+title: 'string slicing (fractional indexes)'
 context: {key: '12345'}
 template: {$eval: 'key[1.5:3.5]'}
 todo: 'https://github.com/taskcluster/json-e/issues/64'
@@ -2930,6 +2930,26 @@ context: {key: {key2: {key3: [1,2,3,4,5]}}}
 template: {$eval: 'key["key2"]["key3"][0] + key["key2"]["key3"][1] + key["key2"]["key3"][2] + key["key2"]["key3"][3] + key["key2"]["key3"][4]'}
 result: 15
 ---
+title: 'indexing number'
+context: {key: 123}
+template: {$eval: 'key[2]'}
+error: true
+---
+title: 'indexing null'
+context: {key: null}
+template: {$eval: 'key[2]'}
+error: true
+---
+title: 'indexing boolean'
+context: {key: true}
+template: {$eval: 'key[2]'}
+error: true
+---
+title: 'indexing object'
+context: {key: {x: 10}}
+template: {$eval: 'key[2]'}
+error: true
+---
 title: 'array length'
 context: {key: [1, 3, 5]}
 template: {$eval: 'key.length'}
@@ -3006,6 +3026,26 @@ error: true
 title: 'array slicing type error (5)'
 context: {key: [1,2,3,4,5]}
 template: {$eval: 'key["a":2]'}
+error: true
+---
+title: 'slicing number'
+context: {key: 123}
+template: {$eval: 'key[2:]'}
+error: true
+---
+title: 'slicing null'
+context: {key: null}
+template: {$eval: 'key[2:]'}
+error: true
+---
+title: 'slicing boolean'
+context: {key: true}
+template: {$eval: 'key[2:]'}
+error: true
+---
+title: 'slicing object'
+context: {key: {x: 10}}
+template: {$eval: 'key[2:]'}
 error: true
 ################################################################################
 ---

--- a/specification.yml
+++ b/specification.yml
@@ -2323,6 +2323,391 @@ title: 'complex logical operation (4)'
 context: {}
 template: {$eval: "4 >= 6 || 2 == 1 + 1"}
 result: true
+---
+title: 'string not'
+context: {a: 'abc'}
+template: {$eval: "!a"}
+error: true
+---
+title: 'number not'
+context: {a: 123}
+template: {$eval: "!a"}
+error: true
+---
+title: 'null not'
+context: {a: null}
+template: {$eval: "!a"}
+error: true
+---
+title: 'object not'
+context: {a: {x: 1}}
+template: {$eval: "!a"}
+error: true
+---
+title: 'array not'
+context: {a: [1, 2]}
+template: {$eval: "!a"}
+error: true
+---
+title: 'string and string'
+context: {a: 'abc', b: 'abc'}
+template: {$eval: "a && b"}
+error: true
+---
+title: 'string or string'
+context: {a: 'abc', b: 'abc'}
+template: {$eval: "a || b"}
+error: true
+---
+title: 'string and number'
+context: {a: 'abc', b: 123}
+template: {$eval: "a && b"}
+error: true
+---
+title: 'string or number'
+context: {a: 'abc', b: 123}
+template: {$eval: "a || b"}
+error: true
+---
+title: 'string and null'
+context: {a: 'abc', b: null}
+template: {$eval: "a && b"}
+error: true
+---
+title: 'string or null'
+context: {a: 'abc', b: null}
+template: {$eval: "a || b"}
+error: true
+---
+title: 'string and boolean'
+context: {a: 'abc', b: true}
+template: {$eval: "a && b"}
+error: true
+---
+title: 'string or boolean'
+context: {a: 'abc', b: true}
+template: {$eval: "a || b"}
+error: true
+---
+title: 'string and object'
+context: {a: 'abc', b: {}}
+template: {$eval: "a && b"}
+error: true
+---
+title: 'string or object'
+context: {a: 'abc', b: {}}
+template: {$eval: "a || b"}
+error: true
+---
+title: 'string and array'
+context: {a: 'abc', b: []}
+template: {$eval: "a && b"}
+error: true
+---
+title: 'string or array'
+context: {a: 'abc', b: []}
+template: {$eval: "a || b"}
+error: true
+---
+title: 'number and string'
+context: {a: 345, b: 'abc'}
+template: {$eval: "a && b"}
+error: true
+---
+title: 'number or string'
+context: {a: 345, b: 'abc'}
+template: {$eval: "a || b"}
+error: true
+---
+title: 'number and number'
+context: {a: 345, b: 123}
+template: {$eval: "a && b"}
+error: true
+---
+title: 'number or number'
+context: {a: 345, b: 123}
+template: {$eval: "a || b"}
+error: true
+---
+title: 'number and null'
+context: {a: 345, b: null}
+template: {$eval: "a && b"}
+error: true
+---
+title: 'number or null'
+context: {a: 345, b: null}
+template: {$eval: "a || b"}
+error: true
+---
+title: 'number and boolean'
+context: {a: 345, b: true}
+template: {$eval: "a && b"}
+error: true
+---
+title: 'number or boolean'
+context: {a: 345, b: true}
+template: {$eval: "a || b"}
+error: true
+---
+title: 'number and object'
+context: {a: 345, b: {}}
+template: {$eval: "a && b"}
+error: true
+---
+title: 'number or object'
+context: {a: 345, b: {}}
+template: {$eval: "a || b"}
+error: true
+---
+title: 'number and array'
+context: {a: 345, b: []}
+template: {$eval: "a && b"}
+error: true
+---
+title: 'number or array'
+context: {a: 345, b: []}
+template: {$eval: "a || b"}
+error: true
+---
+title: 'null and string'
+context: {a: null, b: 'abc'}
+template: {$eval: "a && b"}
+error: true
+---
+title: 'null or string'
+context: {a: null, b: 'abc'}
+template: {$eval: "a || b"}
+error: true
+---
+title: 'null and number'
+context: {a: null, b: 123}
+template: {$eval: "a && b"}
+error: true
+---
+title: 'null or number'
+context: {a: null, b: 123}
+template: {$eval: "a || b"}
+error: true
+---
+title: 'null and null'
+context: {a: null, b: null}
+template: {$eval: "a && b"}
+error: true
+---
+title: 'null or null'
+context: {a: null, b: null}
+template: {$eval: "a || b"}
+error: true
+---
+title: 'null and boolean'
+context: {a: null, b: true}
+template: {$eval: "a && b"}
+error: true
+---
+title: 'null or boolean'
+context: {a: null, b: true}
+template: {$eval: "a || b"}
+error: true
+---
+title: 'null and object'
+context: {a: null, b: {}}
+template: {$eval: "a && b"}
+error: true
+---
+title: 'null or object'
+context: {a: null, b: {}}
+template: {$eval: "a || b"}
+error: true
+---
+title: 'null and array'
+context: {a: null, b: []}
+template: {$eval: "a && b"}
+error: true
+---
+title: 'null or array'
+context: {a: null, b: []}
+template: {$eval: "a || b"}
+error: true
+---
+title: 'boolean and string'
+context: {a: true, b: 'abc'}
+template: {$eval: "a && b"}
+error: true
+---
+title: 'boolean or string'
+context: {a: true, b: 'abc'}
+template: {$eval: "a || b"}
+error: true
+---
+title: 'boolean and number'
+context: {a: true, b: 123}
+template: {$eval: "a && b"}
+error: true
+---
+title: 'boolean or number'
+context: {a: true, b: 123}
+template: {$eval: "a || b"}
+error: true
+---
+title: 'boolean and null'
+context: {a: true, b: null}
+template: {$eval: "a && b"}
+error: true
+---
+title: 'boolean or null'
+context: {a: true, b: null}
+template: {$eval: "a || b"}
+error: true
+---
+title: 'boolean and boolean'
+context: {a: true, b: true}
+template: {$eval: "a && b"}
+result: true
+---
+title: 'boolean or boolean'
+context: {a: true, b: true}
+template: {$eval: "a || b"}
+result: true
+---
+title: 'boolean and object'
+context: {a: true, b: {}}
+template: {$eval: "a && b"}
+error: true
+---
+title: 'boolean or object'
+context: {a: true, b: {}}
+template: {$eval: "a || b"}
+error: true
+---
+title: 'boolean and array'
+context: {a: true, b: []}
+template: {$eval: "a && b"}
+error: true
+---
+title: 'boolean or array'
+context: {a: true, b: []}
+template: {$eval: "a || b"}
+error: true
+---
+title: 'object and string'
+context: {a: {}, b: 'abc'}
+template: {$eval: "a && b"}
+error: true
+---
+title: 'object or string'
+context: {a: {}, b: 'abc'}
+template: {$eval: "a || b"}
+error: true
+---
+title: 'object and number'
+context: {a: {}, b: 123}
+template: {$eval: "a && b"}
+error: true
+---
+title: 'object or number'
+context: {a: {}, b: 123}
+template: {$eval: "a || b"}
+error: true
+---
+title: 'object and null'
+context: {a: {}, b: null}
+template: {$eval: "a && b"}
+error: true
+---
+title: 'object or null'
+context: {a: {}, b: null}
+template: {$eval: "a || b"}
+error: true
+---
+title: 'object and boolean'
+context: {a: {}, b: true}
+template: {$eval: "a && b"}
+error: true
+---
+title: 'object or boolean'
+context: {a: {}, b: true}
+template: {$eval: "a || b"}
+error: true
+---
+title: 'object and object'
+context: {a: {}, b: {}}
+template: {$eval: "a && b"}
+error: true
+---
+title: 'object or object'
+context: {a: {}, b: {}}
+template: {$eval: "a || b"}
+error: true
+---
+title: 'object and array'
+context: {a: {}, b: []}
+template: {$eval: "a && b"}
+error: true
+---
+title: 'object or array'
+context: {a: {}, b: []}
+template: {$eval: "a || b"}
+error: true
+---
+title: 'array and string'
+context: {a: [], b: 'abc'}
+template: {$eval: "a && b"}
+error: true
+---
+title: 'array or string'
+context: {a: [], b: 'abc'}
+template: {$eval: "a || b"}
+error: true
+---
+title: 'array and number'
+context: {a: [], b: 123}
+template: {$eval: "a && b"}
+error: true
+---
+title: 'array or number'
+context: {a: [], b: 123}
+template: {$eval: "a || b"}
+error: true
+---
+title: 'array and null'
+context: {a: [], b: null}
+template: {$eval: "a && b"}
+error: true
+---
+title: 'array or null'
+context: {a: [], b: null}
+template: {$eval: "a || b"}
+error: true
+---
+title: 'array and boolean'
+context: {a: [], b: true}
+template: {$eval: "a && b"}
+error: true
+---
+title: 'array or boolean'
+context: {a: [], b: true}
+template: {$eval: "a || b"}
+error: true
+---
+title: 'array and object'
+context: {a: [], b: {}}
+template: {$eval: "a && b"}
+error: true
+---
+title: 'array or object'
+context: {a: [], b: {}}
+template: {$eval: "a || b"}
+error: true
+---
+title: 'array and array'
+context: {a: [], b: []}
+template: {$eval: "a && b"}
+error: true
+---
+title: 'array or array'
+context: {a: [], b: []}
+template: {$eval: "a || b"}
+error: true
 ################################################################################
 ---
 section: expression language - string operations

--- a/specification.yml
+++ b/specification.yml
@@ -638,6 +638,34 @@ template: {$reverse: {$sort: [3, 4, 1, 2]}}
 result:   [4, 3, 2, 1]
 ################################################################################
 ---
+section: $eval
+---
+title: $eval of an array
+context: {key1: 1, key2: 2}
+template: {$eval: ['key1', 'key2']}
+error: true
+---
+title: $eval of an object
+context: {key1: 1, key2: 2}
+template: {$eval: {k: 'key1'}}
+error: true
+---
+title: $eval of null
+context: {}
+template: {$eval: null}
+error: true
+---
+title: $eval of a number
+context: {}
+template: {$eval: 11}
+error: true
+---
+title: $eval of a boolean
+context: {}
+template: {$eval: true}
+error: true
+################################################################################
+---
 section: builtins
 ---
 title: min (1)

--- a/src/builtins.js
+++ b/src/builtins.js
@@ -1,4 +1,4 @@
-import BuiltinError from './error';
+import {BuiltinError} from './error';
 import fromNow from './from-now';
 import {
   isString, isNumber, isBool,

--- a/src/error.js
+++ b/src/error.js
@@ -39,4 +39,4 @@ class BuiltinError extends BaseError {
   }
 }
 
-export default {SyntaxError, InterpreterError, TemplateError, BuiltinError};
+export {SyntaxError, InterpreterError, TemplateError, BuiltinError};

--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -5,7 +5,7 @@
 import PrattParser from './prattparser';
 import {isString, isNumber, isBool,
   isArray, isObject, isFunction} from './type-utils';
-import InterpreterError from './error';
+import {InterpreterError} from './error';
 
 let expectationError = (operator, expectation) => new InterpreterError(`'${operator}' expects '${expectation}'`);
 

--- a/src/prattparser.js
+++ b/src/prattparser.js
@@ -5,7 +5,7 @@
 
 import Tokenizer from './tokenizer';
 import assert from 'assert';
-import SyntaxError from './error';
+import {SyntaxError} from './error';
 
 let syntaxRuleError = (token, expects) => new SyntaxError(`Found '${token.value}' expected '${expects}'`, token);
 

--- a/test/jsone_test.js
+++ b/test/jsone_test.js
@@ -25,17 +25,26 @@ suite('json-e', () => {
   before(() => tk.freeze(TEST_DATE));
   after(() => tk.reset());
 
-  _.forEach(spec, (C, s) => suite(s, () => C.forEach(c => test(c.title, () => {
-    let result;
-    try {
-      result = jsone(c.template, c.context);
-    } catch (err) {
-      if (!c.error) {
-        throw err;
+  _.forEach(spec, (C, s) => suite(s, function() {
+    C.forEach(c => {
+      let t = function() {
+        let result;
+        try {
+          result = jsone(c.template, c.context);
+        } catch (err) {
+          if (!c.error) {
+            throw err;
+          }
+          return;
+        }
+        assert(!c.error, 'Expected an error');
+        assume(result).eql(c.result);
+      };
+      if (c.todo) {
+        test.skip(c.title, t);
+      } else {
+        test(c.title, t);
       }
-      return;
-    }
-    assert(!c.error, 'Expected an error');
-    assume(result).eql(c.result);
-  }))));
+    });
+  }));
 });


### PR DESCRIPTION
I'll be making a list here as I think of them..

 * [x] division applies floor (or array indexes don't require ints)
 * [x] string interpolation results in a boolean
 * [x] string interpolation results in null
 * [x] string interpolation escaping
 * [x] operator escaping (how do I write a literal `{$eval: foo}`)?
 * [x] object access by named property: `{$eval: "settings[environment]"}`
 * [x] for `$if`, what values are truthy/falsy (empty strings, 0, [], {}, null)
 * [x] access of missing property in expression (`"x.foo"` when `x` has no `foo`)
 * [x] missing `then` in `$if`-`else` expression
 * [x] top-level deletion marker (`{$if: 'false', then: 1}`)
 * [x] deletion marker in an array (`[1, 2, {$if: 'false', then: 1}]`)
 * [x] `$map` on non-array things other than an object
 * [x] `$sort` over multi-digit numbers (1 < 10)
 * [x] `$sort` of mixed numbers and strings and other objects
 * [x] `$sort` of mixed numbers and strings
 * [x] `$sort` of all non-array types
 * [x] `$sort` when `by(var)` returns various types
 * [x] `$reverse` when given a non-array
 * [x] expressions: `==` does deep equality, `!=` does the opposite
 * [x] `$eval` given things other than array, string
 * [x] Numeric literals - floats, different bases, leading zeroes
 * [x] parenthetical grouping
 * [x] all parser operators (infix and unary) over all types
 * [x] string literals with `"` and with `'`
 * [x] array indexing / slicing with invalid types
 * [x] object property access with invalid types
 * [x] min/max with zero args
 * [x] all builtins with funny types
 * [x] `str([..])` formatting
 * [x] boolean literals (true, false)