### PR TITLE
fix (and add more) tests for $flatten

### DIFF
--- a/python-blacklist.txt
+++ b/python-blacklist.txt
@@ -811,3 +811,8 @@ expression language - array access: numeric, noninteger index
 expression language - array slicing: array slicing (noninteger first index)
 expression language - array slicing: array slicing (noninteger last index)
 expression language - array slicing: array slicing (noninteger indexes)
+$flatten: flatten null
+$flatten: flatten an object
+$flatten: flatten an array of strings
+$flatten: flatten an array of numbers
+$flatten: flatten mixed types

--- a/specification.yml
+++ b/specification.yml
@@ -275,9 +275,24 @@ context:  {}
 template: {$flatten: [[]]}
 result:   []
 ---
-title:    flatten nothing
+title:    flatten null
 context:  {}
-template: {$flatten: }
+template: {$flatten: null}
+error:    true
+---
+title:    flatten an object
+context:  {}
+template: {$flatten: {a: 1, b: 2}}
+error:    true
+---
+title:    flatten an array of strings
+context:  {}
+template: {$flatten: ["a", "b"]}
+error:    true
+---
+title:    flatten an array of numbers
+context:  {}
+template: {$flatten: [1, 2]}
 error:    true
 ---
 title:    flatten mixed types


### PR DESCRIPTION
TC-github was down and didn't notice the two missing Python blacklist entries.  This also adds a few more tests.