### PR TITLE
Fix tests for escaping operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ template: {"tc_${name}": "${value}"}
 result: {"tc_foo": "bar"}
 ```
 
+The string `${` can be escaped as `$${`.
+
 ## Operators
 
 JSON-e defines a bunch of operators. Each is represented as an object with a

--- a/specification.yml
+++ b/specification.yml
@@ -58,7 +58,7 @@ result:   {message: 'hello world'}
 title: multiple string interpolation (2)
 context:  {a: 'hello', b: 'world'}
 template: {message: '${a}$$${b}'}
-result:   {message: 'hello$$world'}
+result:   {message: 'hello$${b}'}
 ---
 title: multiple string interpolation (3)
 context:  {a: 'hello', b: 'world'}
@@ -67,11 +67,8 @@ result:   {message: 'hello##world'}
 ---
 title: string interpolation escapes
 context:  {}
-template: {message: 'a literal \\${ in a string'}
-result:   {message: 'a literal ${ in a string'}
-todo:
-    javascript: 'https://github.com/taskcluster/json-e/issues/66'
-    python: 'https://github.com/taskcluster/json-e/issues/66'
+template: {message: 'a literal $${in a string}'}
+result:   {message: 'a literal ${in a string}'}
 ---
 title: string interpolation of keys
 context: {name: 'foo', value: 'bar'}

--- a/src/index.js
+++ b/src/index.js
@@ -20,22 +20,27 @@ let interpolate = (string, context) => {
   let begin = 0;
   let remaining = string;
   let offset;
-  while ((offset = remaining.search(/\${/g)) !== -1) {
-    let v = interpreter.parseUntilTerminator(remaining.slice(offset), 2, '}', context);
-    if (isArray(v.result) || isObject(v.result)) {
-      throw new TemplateError('cannot interpolate array/object: ' + string);
-    }
-
+  while ((offset = remaining.search(/\$?\${/g)) !== -1) {
     result += remaining.slice(0, offset);
 
-    // toString renders null as an empty string, which is not what we want
-    if (v.result === null) {
-      result += 'null';
-    } else {
-      result += v.result.toString();
-    }
+    if (remaining[offset+1] != '$') {
+      let v = interpreter.parseUntilTerminator(remaining.slice(offset), 2, '}', context);
+      if (isArray(v.result) || isObject(v.result)) {
+        throw new TemplateError('cannot interpolate array/object: ' + string);
+      }
 
-    remaining = remaining.slice(offset + v.offset + 1);
+      // toString renders null as an empty string, which is not what we want
+      if (v.result === null) {
+        result += 'null';
+      } else {
+        result += v.result.toString();
+      }
+
+      remaining = remaining.slice(offset + v.offset + 1);
+    } else {
+      result += '${';
+      remaining = remaining.slice(offset + 3);
+    }
   }
   result += remaining;
   return result;


### PR DESCRIPTION
```
title:    interpolate non-json-e operator
context:  {}
template: {$nothing: 1}
result:   {$nothing: 1}
---
title:    escape non-json-e operator
context:  {}
template: {$$nothing: 1}
result:   {$$nothing: 1}
```

I think that the first is a good test, but it's not "interpolating" so it probably needs a new name.

The second should, I think, replace `$$` with `$`.