### PR TITLE
Keys can be interpolated, too

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,14 @@ The bit inside the `${..}` is an expression, and must evaluate to something
 that interpolates obviously into a string (so, a string, number, boolean, or
 null). The expression syntax is described in more detail below.
 
+Note that object keys can be interpolated, too:
+
+```yaml
+context: {name: 'foo', value: 'bar'}
+template: {"tc_${name}": "${value}"}
+result: {"tc_foo": "bar"}
+```
+
 ## Operators
 
 JSON-e defines a bunch of operators. Each is represented as an object with a

--- a/python-blacklist.txt
+++ b/python-blacklist.txt
@@ -872,3 +872,4 @@ expression language - string operations: string slicing (noninteger first index)
 expression language - string operations: string slicing (noninteger second index)
 expression language - string operations: string slicing (noninteger indexes)
 expression language - array slicing: array slicing (floor)
+Initial Minimal Subset: string interpolation of keys

--- a/specification.yml
+++ b/specification.yml
@@ -71,6 +71,11 @@ template: {message: 'a literal \\${ in a string'}
 result:   {message: 'a literal ${ in a string'}
 todo: 'https://github.com/taskcluster/json-e/issues/66'
 ---
+title: string interpolation of keys
+context: {name: 'foo', value: 'bar'}
+template: {"tc_${name}": "${value}"}
+result: {"tc_foo": "bar"}
+---
 title: string interpolation with unbalanced }
 context:  {}
 template: {message: 'tricky ${"}}}}"}'}


### PR DESCRIPTION
```
context: {name: 'foo', value: 'bar'}
template: {"tc_${name}": "${value}"}
```

This needs to be documented and tested.