### PR TITLE
Truthiness fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ yarn.lock
 *.pyc
 .eggs
 json_e.egg-info
+docs/bundle.diff.js

--- a/docs/bundle.js
+++ b/docs/bundle.js
@@ -463,7 +463,7 @@ operators.$if = function (template, context) {
   if (!(0, _typeUtils.isString)(template['$if'])) {
     throw jsonTemplateError('$if can evaluate string expressions only\n', template);
   }
-  if (_interpreter2.default.parse(template['$if'], context)) {
+  if ((0, _typeUtils.isTruthy)(_interpreter2.default.parse(template['$if'], context))) {
     return template.hasOwnProperty('then') ? render(template.then, context) : deleteMarker;
   }
   return template.hasOwnProperty('else') ? render(template.else, context) : deleteMarker;
@@ -478,7 +478,7 @@ operators.$let = function (template, context) {
 
   var context_copy = (0, _assign2.default)(context, variables);
 
-  if (variables === null || (0, _typeUtils.isArray)(variables) || !(0, _typeUtils.isObject)(variables)) {
+  if (!(0, _typeUtils.isObject)(variables)) {
     throw jsonTemplateError('$let operator requires an object as the context\n', template);
   }
 
@@ -736,7 +736,7 @@ var isEqual = function isEqual(a, b) {
     }
     return true;
   }
-  if ((0, _typeUtils.isObject)(a) && (0, _typeUtils.isObject)(b) && !(0, _typeUtils.isArray)(a) && !(0, _typeUtils.isArray)(b)) {
+  if ((0, _typeUtils.isObject)(a) && (0, _typeUtils.isObject)(b)) {
     var keys = (0, _keys2.default)(a).sort();
     if (!isEqual(keys, (0, _keys2.default)(b).sort())) {
       return false;
@@ -915,8 +915,7 @@ prefixRules['number'] = function (token, ctx) {
 
 prefixRules['!'] = function (token, ctx) {
   var operand = ctx.parse('unary');
-  testLogicalOperand('!', operand);
-  return !operand;
+  return !(0, _typeUtils.isTruthy)(operand);
 };
 
 prefixRules['-'] = function (token, ctx) {
@@ -1016,7 +1015,7 @@ infixRules['['] = function (left, token, ctx) {
 };
 
 infixRules['.'] = function (left, token, ctx) {
-  if ((0, _typeUtils.isObject)(left) && !(0, _typeUtils.isArray)(left)) {
+  if ((0, _typeUtils.isObject)(left)) {
     var key = ctx.require('identifier').value;
     if (left.hasOwnProperty(key)) {
       return left[key];
@@ -1058,13 +1057,11 @@ infixRules['=='] = infixRules['!='] = infixRules['<='] = infixRules['>='] = infi
 infixRules['||'] = infixRules['&&'] = function (left, token, ctx) {
   var operator = token.kind;
   var right = ctx.parse(operator);
-  testLogicalOperand(operator, left);
-  testLogicalOperand(operator, right);
   switch (operator) {
     case '||':
-      return left || right;
+      return (0, _typeUtils.isTruthy)(left) || (0, _typeUtils.isTruthy)(right);
     case '&&':
-      return left && right;
+      return (0, _typeUtils.isTruthy)(left) && (0, _typeUtils.isTruthy)(right);
     default:
       throw new Error('no rule for boolean operator: ' + operator);
   }
@@ -1072,7 +1069,7 @@ infixRules['||'] = infixRules['&&'] = function (left, token, ctx) {
 
 infixRules['in'] = function (left, token, ctx) {
   var right = ctx.parse(token.kind);
-  if ((0, _typeUtils.isObject)(right) && !(0, _typeUtils.isArray)(right)) {
+  if ((0, _typeUtils.isObject)(right)) {
     if ((0, _typeUtils.isNumber)(left)) {
       throw expectationError('Infix: in', 'String query on Object');
     }
@@ -1556,7 +1553,7 @@ var utils = {
     return expr instanceof Array;
   },
   isObject: function isObject(expr) {
-    return expr instanceof Object;
+    return expr instanceof Object && !(expr instanceof Array);
   },
   isFunction: function isFunction(expr) {
     return expr instanceof Function;
@@ -1607,6 +1604,9 @@ var utils = {
       return result;
     }
     return false;
+  },
+  isTruthy: function isTruthy(expr) {
+    return expr !== null && (utils.isArray(expr) && expr.length > 0 || utils.isObject(expr) && (0, _keys2.default)(expr).length > 0 || utils.isString(expr) && expr.length > 0 || utils.isNumber(expr) && expr !== 0 || utils.isBool(expr) && expr);
   }
 };
 

--- a/python-blacklist.txt
+++ b/python-blacklist.txt
@@ -679,10 +679,14 @@ expression language - operator type errors: exponentiation of array by arrays
 expression language - operator type errors: unary negation of array
 expression language - operator type errors: unary plus of array
 expression language - logic: string not
+expression language - logic: empty string not
 expression language - logic: number not
+expression language - logic: zero not
 expression language - logic: null not
 expression language - logic: object not
+expression language - logic: empty object not
 expression language - logic: array not
+expression language - logic: empty array not
 expression language - logic: string and string
 expression language - logic: string or string
 expression language - logic: string and number

--- a/specification.yml
+++ b/specification.yml
@@ -237,7 +237,6 @@ title: $if->then->else, empty array
 context: {cond: [], key: 'world'}
 template: {$if: 'cond', then: "t", else: "f"}
 result: f
-todo: 'https://github.com/taskcluster/json-e/issues/68'
 ---
 title: $if->then->else, nonempty array
 context: {cond: [1, 2], key: 'world'}
@@ -248,7 +247,6 @@ title: $if->then->else, empty object
 context: {cond: {}, key: 'world'}
 template: {$if: 'cond', then: "t", else: "f"}
 result: f
-todo: 'https://github.com/taskcluster/json-e/issues/68'
 ---
 title: $if->then->else, nonempty object
 context: {cond: {a: 2}, key: 'world'}

--- a/specification.yml
+++ b/specification.yml
@@ -2632,237 +2632,257 @@ result: true
 title: 'string not'
 context: {a: 'abc'}
 template: {$eval: "!a"}
-error: true
+result: false
+---
+title: 'empty string not'
+context: {a: ''}
+template: {$eval: "!a"}
+result: true
 ---
 title: 'number not'
 context: {a: 123}
 template: {$eval: "!a"}
-error: true
+result: false
+---
+title: 'zero not'
+context: {a: 0}
+template: {$eval: "!a"}
+result: true
 ---
 title: 'null not'
 context: {a: null}
 template: {$eval: "!a"}
-error: true
+result: true
 ---
 title: 'object not'
 context: {a: {x: 1}}
 template: {$eval: "!a"}
-error: true
+result: false
+---
+title: 'empty object not'
+context: {a: {}}
+template: {$eval: "!a"}
+result: true
 ---
 title: 'array not'
 context: {a: [1, 2]}
 template: {$eval: "!a"}
-error: true
+result: false
+---
+title: 'empty array not'
+context: {a: []}
+template: {$eval: "!a"}
+result: true
 ---
 title: 'string and string'
 context: {a: 'abc', b: 'abc'}
 template: {$eval: "a && b"}
-error: true
+result: true
 ---
 title: 'string or string'
 context: {a: 'abc', b: 'abc'}
 template: {$eval: "a || b"}
-error: true
+result: true
 ---
 title: 'string and number'
 context: {a: 'abc', b: 123}
 template: {$eval: "a && b"}
-error: true
+result: true
 ---
 title: 'string or number'
 context: {a: 'abc', b: 123}
 template: {$eval: "a || b"}
-error: true
+result: true
 ---
 title: 'string and null'
 context: {a: 'abc', b: null}
 template: {$eval: "a && b"}
-error: true
+result: false
 ---
 title: 'string or null'
 context: {a: 'abc', b: null}
 template: {$eval: "a || b"}
-error: true
+result: true
 ---
 title: 'string and boolean'
 context: {a: 'abc', b: true}
 template: {$eval: "a && b"}
-error: true
+result: true
 ---
 title: 'string or boolean'
 context: {a: 'abc', b: true}
 template: {$eval: "a || b"}
-error: true
+result: true
 ---
 title: 'string and object'
 context: {a: 'abc', b: {}}
 template: {$eval: "a && b"}
-error: true
+result: false
 ---
 title: 'string or object'
 context: {a: 'abc', b: {}}
 template: {$eval: "a || b"}
-error: true
+result: true
 ---
 title: 'string and array'
 context: {a: 'abc', b: []}
 template: {$eval: "a && b"}
-error: true
+result: false
 ---
 title: 'string or array'
 context: {a: 'abc', b: []}
 template: {$eval: "a || b"}
-error: true
+result: true
 ---
 title: 'number and string'
 context: {a: 345, b: 'abc'}
 template: {$eval: "a && b"}
-error: true
+result: true
 ---
 title: 'number or string'
 context: {a: 345, b: 'abc'}
 template: {$eval: "a || b"}
-error: true
+result: true
 ---
 title: 'number and number'
 context: {a: 345, b: 123}
 template: {$eval: "a && b"}
-error: true
+result: true
 ---
 title: 'number or number'
 context: {a: 345, b: 123}
 template: {$eval: "a || b"}
-error: true
+result: true
 ---
 title: 'number and null'
 context: {a: 345, b: null}
 template: {$eval: "a && b"}
-error: true
+result: false
 ---
 title: 'number or null'
 context: {a: 345, b: null}
 template: {$eval: "a || b"}
-error: true
+result: true
 ---
 title: 'number and boolean'
 context: {a: 345, b: true}
 template: {$eval: "a && b"}
-error: true
+result: true
 ---
 title: 'number or boolean'
 context: {a: 345, b: true}
 template: {$eval: "a || b"}
-error: true
+result: true
 ---
 title: 'number and object'
 context: {a: 345, b: {}}
 template: {$eval: "a && b"}
-error: true
+result: false
 ---
 title: 'number or object'
 context: {a: 345, b: {}}
 template: {$eval: "a || b"}
-error: true
+result: true
 ---
 title: 'number and array'
 context: {a: 345, b: []}
 template: {$eval: "a && b"}
-error: true
+result: false
 ---
 title: 'number or array'
 context: {a: 345, b: []}
 template: {$eval: "a || b"}
-error: true
+result: true
 ---
 title: 'null and string'
 context: {a: null, b: 'abc'}
 template: {$eval: "a && b"}
-error: true
+result: false
 ---
 title: 'null or string'
 context: {a: null, b: 'abc'}
 template: {$eval: "a || b"}
-error: true
+result: true
 ---
 title: 'null and number'
 context: {a: null, b: 123}
 template: {$eval: "a && b"}
-error: true
+result: false
 ---
 title: 'null or number'
 context: {a: null, b: 123}
 template: {$eval: "a || b"}
-error: true
+result: true
 ---
 title: 'null and null'
 context: {a: null, b: null}
 template: {$eval: "a && b"}
-error: true
+result: false
 ---
 title: 'null or null'
 context: {a: null, b: null}
 template: {$eval: "a || b"}
-error: true
+result: false
 ---
 title: 'null and boolean'
 context: {a: null, b: true}
 template: {$eval: "a && b"}
-error: true
+result: false
 ---
 title: 'null or boolean'
 context: {a: null, b: true}
 template: {$eval: "a || b"}
-error: true
+result: true
 ---
 title: 'null and object'
 context: {a: null, b: {}}
 template: {$eval: "a && b"}
-error: true
+result: false
 ---
 title: 'null or object'
 context: {a: null, b: {}}
 template: {$eval: "a || b"}
-error: true
+result: false
 ---
 title: 'null and array'
 context: {a: null, b: []}
 template: {$eval: "a && b"}
-error: true
+result: false
 ---
 title: 'null or array'
 context: {a: null, b: []}
 template: {$eval: "a || b"}
-error: true
+result: false
 ---
 title: 'boolean and string'
 context: {a: true, b: 'abc'}
 template: {$eval: "a && b"}
-error: true
+result: true
 ---
 title: 'boolean or string'
 context: {a: true, b: 'abc'}
 template: {$eval: "a || b"}
-error: true
+result: true
 ---
 title: 'boolean and number'
 context: {a: true, b: 123}
 template: {$eval: "a && b"}
-error: true
+result: true
 ---
 title: 'boolean or number'
 context: {a: true, b: 123}
 template: {$eval: "a || b"}
-error: true
+result: true
 ---
 title: 'boolean and null'
 context: {a: true, b: null}
 template: {$eval: "a && b"}
-error: true
+result: false
 ---
 title: 'boolean or null'
 context: {a: true, b: null}
 template: {$eval: "a || b"}
-error: true
+result: true
 ---
 title: 'boolean and boolean'
 context: {a: true, b: true}
@@ -2877,142 +2897,142 @@ result: true
 title: 'boolean and object'
 context: {a: true, b: {}}
 template: {$eval: "a && b"}
-error: true
+result: false
 ---
 title: 'boolean or object'
 context: {a: true, b: {}}
 template: {$eval: "a || b"}
-error: true
+result: true
 ---
 title: 'boolean and array'
 context: {a: true, b: []}
 template: {$eval: "a && b"}
-error: true
+result: false
 ---
 title: 'boolean or array'
 context: {a: true, b: []}
 template: {$eval: "a || b"}
-error: true
+result: true
 ---
 title: 'object and string'
 context: {a: {}, b: 'abc'}
 template: {$eval: "a && b"}
-error: true
+result: false
 ---
 title: 'object or string'
 context: {a: {}, b: 'abc'}
 template: {$eval: "a || b"}
-error: true
+result: true
 ---
 title: 'object and number'
 context: {a: {}, b: 123}
 template: {$eval: "a && b"}
-error: true
+result: false
 ---
 title: 'object or number'
 context: {a: {}, b: 123}
 template: {$eval: "a || b"}
-error: true
+result: true
 ---
 title: 'object and null'
 context: {a: {}, b: null}
 template: {$eval: "a && b"}
-error: true
+result: false
 ---
 title: 'object or null'
 context: {a: {}, b: null}
 template: {$eval: "a || b"}
-error: true
+result: false
 ---
 title: 'object and boolean'
 context: {a: {}, b: true}
 template: {$eval: "a && b"}
-error: true
+result: false
 ---
 title: 'object or boolean'
 context: {a: {}, b: true}
 template: {$eval: "a || b"}
-error: true
+result: true
 ---
 title: 'object and object'
 context: {a: {}, b: {}}
 template: {$eval: "a && b"}
-error: true
+result: false
 ---
 title: 'object or object'
 context: {a: {}, b: {}}
 template: {$eval: "a || b"}
-error: true
+result: false
 ---
 title: 'object and array'
 context: {a: {}, b: []}
 template: {$eval: "a && b"}
-error: true
+result: false
 ---
 title: 'object or array'
 context: {a: {}, b: []}
 template: {$eval: "a || b"}
-error: true
+result: false
 ---
 title: 'array and string'
 context: {a: [], b: 'abc'}
 template: {$eval: "a && b"}
-error: true
+result: false
 ---
 title: 'array or string'
 context: {a: [], b: 'abc'}
 template: {$eval: "a || b"}
-error: true
+result: true
 ---
 title: 'array and number'
 context: {a: [], b: 123}
 template: {$eval: "a && b"}
-error: true
+result: false
 ---
 title: 'array or number'
 context: {a: [], b: 123}
 template: {$eval: "a || b"}
-error: true
+result: true
 ---
 title: 'array and null'
 context: {a: [], b: null}
 template: {$eval: "a && b"}
-error: true
+result: false
 ---
 title: 'array or null'
 context: {a: [], b: null}
 template: {$eval: "a || b"}
-error: true
+result: false
 ---
 title: 'array and boolean'
 context: {a: [], b: true}
 template: {$eval: "a && b"}
-error: true
+result: false
 ---
 title: 'array or boolean'
 context: {a: [], b: true}
 template: {$eval: "a || b"}
-error: true
+result: true
 ---
 title: 'array and object'
 context: {a: [], b: {}}
 template: {$eval: "a && b"}
-error: true
+result: false
 ---
 title: 'array or object'
 context: {a: [], b: {}}
 template: {$eval: "a || b"}
-error: true
+result: false
 ---
 title: 'array and array'
 context: {a: [], b: []}
 template: {$eval: "a && b"}
-error: true
+result: false
 ---
 title: 'array or array'
 context: {a: [], b: []}
 template: {$eval: "a || b"}
-error: true
+result: false
 ################################################################################
 ---
 section: expression language - string operations
@@ -4378,29 +4398,4 @@ error: true
 title: 'Infix >= type error'
 context: {}
 template: {$eval: '3 >= "hello"'}
-error: true
----
-title: 'Prefix logical not type error'
-context: {key: 'hello'}
-template: {$eval: '!key'}
-error: true
----
-title: 'Infix or type error (1)'
-context: {tt: true, key: 'hello'}
-template: {$eval: 'tt || key'}
-error: true
----
-title: 'Infix or type error (2)'
-context: {tt: true, key: 'hello'}
-template: {$eval: 'key || tt'}
-error: true
----
-title: 'Infix and type error (1)'
-context: {tt: true, key: 'hello'}
-template: {$eval: 'tt && key'}
-error: true
----
-title: 'Infix and type error (2)'
-context: {tt: true, key: 'hello'}
-template: {$eval: 'key && tt'}
 error: true

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import assert from 'assert';
 import {
   isString, isNumber, isBool,
   isArray, isObject, isFunction,
+  isTruthy,
 } from './type-utils';
 import builtins from './builtins';
 import {TemplateError} from './error';
@@ -86,7 +87,7 @@ operators.$if = (template, context) => {
   if (!isString(template['$if'])) {
     throw jsonTemplateError('$if can evaluate string expressions only\n', template);
   }
-  if (interpreter.parse(template['$if'], context)) {
+  if (isTruthy(interpreter.parse(template['$if'], context))) {
     return template.hasOwnProperty('then') ? render(template.then, context) : deleteMarker;
   }
   return template.hasOwnProperty('else') ? render(template.else, context) : deleteMarker;

--- a/src/index.js
+++ b/src/index.js
@@ -102,7 +102,7 @@ operators.$let = (template, context) => {
 
   var context_copy = Object.assign(context, variables);
 
-  if (variables === null || isArray(variables) || !isObject(variables)) {
+  if (!isObject(variables)) {
     throw jsonTemplateError('$let operator requires an object as the context\n', template);
   }
 

--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -4,7 +4,7 @@
 */
 import PrattParser from './prattparser';
 import {isString, isNumber, isInteger, isBool,
-  isArray, isObject, isFunction} from './type-utils';
+  isArray, isObject, isFunction, isTruthy} from './type-utils';
 import {InterpreterError} from './error';
 
 let expectationError = (operator, expectation) => new InterpreterError(`'${operator}' expects '${expectation}'`);
@@ -164,8 +164,7 @@ prefixRules['number'] = (token, ctx) => {
 
 prefixRules['!'] = (token, ctx) => {
   let operand = ctx.parse('unary');
-  testLogicalOperand('!', operand);
-  return !operand;
+  return !isTruthy(operand);
 };
 
 prefixRules['-'] = (token, ctx) => {
@@ -290,11 +289,9 @@ infixRules['>='] = infixRules['<'] =  infixRules['>']
 infixRules['||'] = infixRules['&&'] = (left, token, ctx) => {
   let operator = token.kind;
   let right = ctx.parse(operator);
-  testLogicalOperand(operator, left);
-  testLogicalOperand(operator, right);
   switch (operator) {
-    case '||':  return left || right;
-    case '&&':  return left && right;
+    case '||':  return isTruthy(left) || isTruthy(right);
+    case '&&':  return isTruthy(left) && isTruthy(right);
     default:    throw new Error('no rule for boolean operator: ' + operator);
   }
 };

--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -16,7 +16,7 @@ let isEqual = (a, b) =>  {
     }
     return true;
   }
-  if (isObject(a) && isObject(b) && !isArray(a) && !isArray(b)) {
+  if (isObject(a) && isObject(b)) {
     let keys = Object.keys(a).sort();
     if (!isEqual(keys, Object.keys(b).sort())) { return false; }
     for (let k of keys) {
@@ -253,7 +253,7 @@ infixRules['**'] = (left, token, ctx) => {
 infixRules['['] = (left, token, ctx) => parseInterval(left, token, ctx);
 
 infixRules['.'] = (left, token, ctx) => {
-  if (isObject(left) && !isArray(left)) {
+  if (isObject(left)) {
     let key = ctx.require('identifier').value;
     if (left.hasOwnProperty(key)) {
       return left[key];
@@ -301,7 +301,7 @@ infixRules['||'] = infixRules['&&'] = (left, token, ctx) => {
 
 infixRules['in'] = (left, token, ctx) => {
   let right = ctx.parse(token.kind);
-  if (isObject(right) && !isArray(right)) {
+  if (isObject(right)) {
     if (isNumber(left)) {
       throw expectationError('Infix: in', 'String query on Object');
     }

--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -127,7 +127,7 @@ let testComparisonOperands = (operator, left, right) => {
 
   let test = ['>=', '<=', '<', '>'].some(v => v === operator)
               && (isNumber(left) && isNumber(right) || isString(left) && isString(right));
-  
+
   if (!test) {
     throw expectationError(`infix: ${operator}`, `numbers/strings ${operator} numbers/strings`);
   }
@@ -136,8 +136,8 @@ let testComparisonOperands = (operator, left, right) => {
 
 let testMathOperands = (operator, left, right) => {
   if (operator === '+' && !(isNumber(left) && isNumber(right) || isString(left) && isString(right))) {
-    throw expectationError('infix: +', 'number/string + number/string'); 
-  } 
+    throw expectationError('infix: +', 'number/string + number/string');
+  }
   if (['-', '*', '/', '**'].some(v => v === operator) && !(isNumber(left) && isNumber(right))) {
     throw expectationError(`infix: ${operator}`, `number ${operator} number`);
   }
@@ -170,7 +170,7 @@ prefixRules['!'] = (token, ctx) => {
 
 prefixRules['-'] = (token, ctx) => {
   let v = ctx.parse('unary');
-  
+
   if (!isNumber(v)) {
     throw expectationError('unary: -', 'number');
   }
@@ -202,8 +202,8 @@ prefixRules['null'] = (token, ctx) => {
 prefixRules['['] = (token, ctx) => parseList(ctx, ',', ']');
 
 prefixRules['('] = (token, ctx) => {
-  let v = ctx.parse(); 
-  ctx.require(')'); 
+  let v = ctx.parse();
+  ctx.require(')');
   return v;
 };
 
@@ -270,8 +270,8 @@ infixRules['('] =  (left, token, ctx) => {
   throw expectationError('infix: f(args)', 'f to be function');
 };
 
-infixRules['=='] = infixRules['!='] = infixRules['<='] = 
-infixRules['>='] = infixRules['<'] =  infixRules['>'] 
+infixRules['=='] = infixRules['!='] = infixRules['<='] =
+infixRules['>='] = infixRules['<'] =  infixRules['>']
   =  (left, token, ctx) => {
     let operator = token.kind;
     let right = ctx.parse(operator);
@@ -340,8 +340,8 @@ module.exports = new PrattParser({
     ['in'],
     ['||'],
     ['&&'],
-  	['==', '!='],
-  	['>=', '<=', '<', '>'],
+    ['==', '!='],
+    ['>=', '<=', '<', '>'],
     ['+', '-'],
     ['*', '/'],
     ['**-right-associative'],

--- a/src/type-utils.js
+++ b/src/type-utils.js
@@ -4,7 +4,7 @@ let utils = {
   isInteger:  expr => typeof expr === 'number' && Number.isInteger(expr),
   isBool:     expr => typeof expr === 'boolean',
   isArray:    expr => expr instanceof Array,
-  isObject:   expr => expr instanceof Object,
+  isObject:   expr => expr instanceof Object && !(expr instanceof Array),
   isFunction: expr => expr instanceof Function,
   isJSON:     expr => {
     if (utils.isString(expr) || utils.isNumber(expr) || utils.isBool(expr) || expr === null) {
@@ -32,7 +32,7 @@ let utils = {
   isTruthy: expr => {
     return expr!== null && (
       utils.isArray(expr) && expr.length > 0 ||
-      utils.isObject(expr) && !(expr instanceof Array) && Object.keys(expr).length > 0 ||
+      utils.isObject(expr) && Object.keys(expr).length > 0 ||
       utils.isString(expr) && expr.length > 0 ||
       utils.isNumber(expr) && expr !== 0 ||
       utils.isBool(expr) && expr

--- a/src/type-utils.js
+++ b/src/type-utils.js
@@ -29,6 +29,15 @@ let utils = {
     }
     return false;
   },
+  isTruthy: expr => {
+    return expr!== null && (
+      utils.isArray(expr) && expr.length > 0 ||
+      utils.isObject(expr) && !(expr instanceof Array) && Object.keys(expr).length > 0 ||
+      utils.isString(expr) && expr.length > 0 ||
+      utils.isNumber(expr) && expr !== 0 ||
+      utils.isBool(expr) && expr
+    );
+  },
 };
 
 module.exports = utils;


### PR DESCRIPTION
This is most of the work to fix #68 other than updating the documentation. It ends up changing a lot of the spec actually. 

I also changed the semantics of `isObject` to assert that it is also not an Array. This might be less correct, but it is also less surprising to me. 90% of the code we had where we were checking for `isObject` we had a `!isArray` right next to it. It is a revision on its own in this PR, so if we don't like this change, it is easy to drop!