### PR TITLE
Add github env to deploys

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -129,6 +129,7 @@ tasks:
     workerType: '{{ taskcluster.docker.workerType }}'
     extra:
       github:
+        env: true
         events:
           - push
         branches:


### PR DESCRIPTION
This is needed to get the env vars. I find myself wondering why this defaults to false O_o