### PR TITLE
put tokens in the same order for python as for javascript

### DIFF
--- a/jsone/interpreter.py
+++ b/jsone/interpreter.py
@@ -35,12 +35,12 @@ class ExpressionEvaluator(PrattParser):
         'number': '[0-9]+(?:\\.[0-9]+)?',
         'identifier': '[a-zA-Z_][a-zA-Z_0-9]*',
         'string': '\'[^\']*\'|"[^"]*"',
-        # disambiguate '* *' from '**'
-        '*': '\*(?!\*)',
     }
-    tokens = list('+-*/[].(){}:,') + [
-        '**', '>=', '<=', '<', '>', '==', '!=', '!', '&&', '||', 'true',
-        'false', 'in', 'null', 'number', 'identifier', 'string']
+    tokens = [
+        '**', '+', '-', '*', '/', '[', ']', '.', '(', ')', '{', '}', ':', ',',
+        '>=', '<=', '<', '>', '==', '!=', '!', '&&', '||', 'true', 'false', 'in',
+        'null', 'number', 'identifier', 'string',
+    ]
     precedence = [
         ['in'],
         ['||'],

--- a/jsone/prattparser.py
+++ b/jsone/prattparser.py
@@ -79,7 +79,8 @@ class PrattParser(with_metaclass(PrattParserMeta, object)):
     # regular expressions for tokens that do not match themselves
     patterns = {}
 
-    # all token kinds
+    # all token kinds (note that order matters - the first matching token
+    # will be returned)
     tokens = []
 
     # precedence of tokens, as a list of lists, from lowest to highest

--- a/src/prattparser.js
+++ b/src/prattparser.js
@@ -15,6 +15,7 @@ class PrattParser {
          precedence, prefixRules, infixRules} = Object.assign({}, {
            ignore: null,
            patterns: {},
+           // NOTE: order matters for tokens - first match is used
            tokens: [],
            precedence: [],
            prefixRules: {},


### PR DESCRIPTION
It turns out that order is significant for the `tokens` array