### PR TITLE
Test string escaping

### DIFF
--- a/specification.yml
+++ b/specification.yml
@@ -1406,6 +1406,16 @@ context:  {}
 template: {$eval: '"three!"'}
 result: 'three!'
 ---
+title:    string literal escape with backslash (not supported)
+context:  {}
+template: {$eval: '"backslash\\"maybe"'}
+error: true
+---
+title:    string literal escape with doubling (not supported)
+context:  {}
+template: {$eval: '"doubled""maybe"'}
+error: true
+---
 title:    boolean literals
 context:  {}
 template: {$eval: '[true, false]'}

--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -113,10 +113,7 @@ let accessProperty = (left, a, b, isInterval) => {
 };
 
 let parseString = (str) => {
-  if (str[0] === '"') {
-    return str.replace('"', '\"').slice(1, -1);
-  }
-  return str.replace('\"', '"').slice(1, -1);
+  return str.slice(1, -1);
 };
 
 let testComparisonOperands = (operator, left, right) => {


### PR DESCRIPTION
I'm not sure what this code is supposed to do, but let's test it to find out, and make sure the JS and Python implementations behave identically:
```js
let parseString = (str) => {
  if (str[0] === '"') {
    return str.replace('"', '\"').slice(1, -1);
  }
  return str.replace('\"', '"').slice(1, -1);
};
```