### PR TITLE
let is not evaluating its values

### DIFF
--- a/specification.yml
+++ b/specification.yml
@@ -534,6 +534,16 @@ template: {$let: {ts: 100, foo: 200,}, in: [{$eval: "ts+foo"}, {$eval: "ts-foo"}
 context:  {}
 result:   [300, -100, 20000]
 ---
+title:    let with evaluated values
+template: {$let: {thirty: {$eval: "10 + 20"}}, in: {$eval: "thirty+5"}}
+context:  {}
+result:   35
+---
+title:    let with evaluated context
+template: {$let: {$eval: '{"thirty": 10 + 20}'}, in: {$eval: "thirty+5"}}
+context:  {}
+result:   35
+---
 title:    context overriding
 template: {$let: {x: 20}, in: {$eval: "x + y"}}
 context:  {x: 10, y: 1}

--- a/src/index.js
+++ b/src/index.js
@@ -101,7 +101,7 @@ operators.$json = (template, context) => {
 };
 
 operators.$let = (template, context) => {
-  let variables = template['$let'];
+  let variables = render(template['$let'], context);
 
   var context_copy = Object.assign(context, variables);
 

--- a/test/test_specification.py
+++ b/test/test_specification.py
@@ -33,12 +33,13 @@ def test():
             try:
                 res = jsone.render(spec['template'], spec['context'])
             except jsone.JSONTemplateError as e:
+                if 'error' not in spec:
+                    raise
                 exc = e
             if 'error' in spec:
                 assert exc, "expected exception"
             else:
-                if exc:
-                    raise exc
+                assert not exc
                 assert res == spec['result'], \
                     '{!r} != {!r}'.format(res, spec['result'])
         return test


### PR DESCRIPTION
```yaml
template:
  $let:
    x: {$eval: "min(1, 2)"}
  in:
    ['x-is', {$eval: 'x'}]
result:
  ['x-is', 1]
```