### PR TITLE
Make x['y'] return null, not raise an error, unlike x.y

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ supports the following:
 * Boolean operators (`||`, `&&`, `!`)
 * Identifiers referring to variables (matching `/[a-zA-Z_][a-zA-Z_0-9]*/`)
 * Object property access: `obj.prop` or `obj["prop"]`
+  * `obj,prop` is an error if there is no such property; in the same case `obj["prop"]` evaluates to `null`.
 * Array and string indexing and slicing with Python semantics
   * `array[1]` -- second element of array (zero-indexed)
   * `array[1:4]` -- second through fourth elements of the array (the slice includes the left index and excludes the right index)

--- a/jsone/interpreter.py
+++ b/jsone/interpreter.py
@@ -267,13 +267,18 @@ def accessProperty(value, a, b, is_interval):
         else:
             try:
                 return value[a]
+            except IndexError:
+                raise ExpressionError('index out of bounds')
             except TypeError:
                 raise ExpressionError.expectation('[..]', 'integer')
 
     if not isinstance(value, dict):
         raise ExpressionError.expectation('[..]', 'object, array, or string')
+    if not isinstance(a, string):
+        raise ExpressionError.expectation('[..]', 'string index')
 
     try:
         return value[a]
     except KeyError:
-        raise ExpressionError('{} not found in {}'.format(a, json.dumps(value)))
+        return None
+        #raise ExpressionError('{} not found in {}'.format(a, json.dumps(value)))

--- a/specification.yml
+++ b/specification.yml
@@ -3241,7 +3241,7 @@ error: true
 title: 'missing property by name'
 context: {key: {a: 1}}
 template: {$eval: 'key["b"]'}
-error: true
+result: null
 ---
 title: 'nested property access with object value'
 context: {key: {key2: {key3: {a: 1}}}}
@@ -3305,6 +3305,16 @@ title: 'string index'
 context: {key: [1,2,3,4,5]}
 template: {$eval: 'key["a"]'}
 error: true
+---
+title: 'too-large index'
+context: {key: [1,2,3,4,5]}
+template: {$eval: 'key[999]'}
+error: true
+---
+title: 'negative index'
+context: {key: [1,2,3,4,5]}
+template: {$eval: 'key[-1]'}
+result: 5
 ---
 title: 'nested, in property accesses'
 context: {key: {key2: {key3: [1,2,3,4,5]}}}

--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -97,6 +97,9 @@ let accessProperty = (left, a, b, isInterval) => {
 
     // for -ve index access
     a = a < 0 ? (left.length + a) % left.length : a;
+    if (a >= left.length) {
+      throw new InterpreterError('index out of bounds');
+    }
     return left[a];
   }
 
@@ -105,14 +108,15 @@ let accessProperty = (left, a, b, isInterval) => {
     throw new InterpreterError('cannot access properties from non-objects');
   }
 
-  if (!left.hasOwnProperty(a)) {
-    throw new InterpreterError(`'${a}' not found in ${JSON.stringify(left, null, '\t')}`);
+  if (!isString(a)) {
+    throw new InterpreterError('object keys must be strings');
   }
 
-  if (isString(a)) {
+  if (left.hasOwnProperty(a)) {
     return left[a];
+  } else {
+    return null;
   }
-  throw new InterpreterError('cannot use non strings/numbers as keys');
 };
 
 let parseString = (str) => {
@@ -257,7 +261,7 @@ infixRules['.'] = (left, token, ctx) => {
     if (left.hasOwnProperty(key)) {
       return left[key];
     }
-    throw new InterpreterError('can only access own properties of objects');
+    throw new InterpreterError('object has no property ' + key);
   }
   throw expectationError('infix: .', 'objects');
 };


### PR DESCRIPTION
This also fixes up some testing for array indexing, making array indexes
greater than the array length raise an error.

Fixes #77.