### PR TITLE
JSON representations of dates look different

### DIFF
--- a/jsone/shared.py
+++ b/jsone/shared.py
@@ -84,15 +84,6 @@ def stringDate(date):
     string = datefmt_re.sub(r'\1Z', string)
     return string
 
-    # If there is no timezone and no Z added, we'll add one at the end.
-    # This is just to be fully compliant with:
-    # https://tools.ietf.org/html/rfc3339#section-5.6
-    if string.endswith('+00:00'):
-        return string[:-6] + 'Z'
-    if date.utcoffset() is None and string[-1] != 'Z':
-        return string + 'Z'
-    return string
-
 # the base class for strings, regardless of python version
 try:
     string = basestring

--- a/jsone/shared.py
+++ b/jsone/shared.py
@@ -75,7 +75,7 @@ def fromNow(offset):
     return stringDate(utcnow() + delta if future else utcnow() - delta)
 
 
-datefmt_re = re.compile(r'(\.[0-9]{3})[0-9]*\+00:00')
+datefmt_re = re.compile(r'(\.[0-9]{3})[0-9]*(\+00:00)?')
 
 
 def stringDate(date):

--- a/test/prop_test.py
+++ b/test/prop_test.py
@@ -83,7 +83,7 @@ def make_strategies():
         lambda children: lists(children) | dictionaries(properties(), children))
 
     return dict(
-        when=integers(min_value=1399283355, max_value=1699283363),
+        when=floats(min_value=1399283355.0, max_value=1699283363.0, allow_nan=False, allow_infinity=False),
         template=json_strategy(),
         context=dictionaries(prefixed_identifiers(), json_strategy()))
 


### PR DESCRIPTION
```
AssertionError: ['2014-05-05T09:49:15'] != ['2014-05-05T09:49:15.000Z']
-------------------- >> begin captured stdout << ---------------------
Falsifying example: test_json(when=1399283355, template=[{'$fromNow': ''}], context={})
```

I think this just happens when the date is an integer number of seconds.