### PR TITLE
Added test cases for array indexes out of range

### DIFF
--- a/specification.yml
+++ b/specification.yml
@@ -1593,6 +1593,31 @@ context: {a: [1,2,3,4]}
 template: {$eval: 'a[:-2]'}
 result: [1,2]
 ---
+title: array index out of range
+context: {a: [1,2,3,4]}
+template: {$eval: 'a[10]'}
+error: true
+---
+title: array slice partially out of range
+context: {a: [1,2,3,4]}
+template: {$eval: 'a[2:10]'}
+error: true
+---
+title: array slice completely out of range
+context: {a: [1,2,3,4]}
+template: {$eval: 'a[8:10]'}
+error: true
+---
+title: array slice negative out of range
+context: {a: [1,2,3,4]}
+template: {$eval: 'a[2:-10]'}
+error: true
+---
+title: array slice negative range
+context: {a: [1,2,3,4]}
+template: {$eval: 'a[2:-3]'}
+error: true
+---
 title: function min(contextValue, contextValue)
 context: {a: 1, b: 2}
 template: {$eval: 'min(a, b)'}

--- a/specification.yml
+++ b/specification.yml
@@ -1593,11 +1593,6 @@ context: {a: [1,2,3,4]}
 template: {$eval: 'a[:-2]'}
 result: [1,2]
 ---
-title: array index out of range
-context: {a: [1,2,3,4]}
-template: {$eval: 'a[10]'}
-error: true
----
 title: array slice partially out of range
 context: {a: [1,2,3,4]}
 template: {$eval: 'a[2:10]'}

--- a/specification.yml
+++ b/specification.yml
@@ -1601,22 +1601,27 @@ error: true
 title: array slice partially out of range
 context: {a: [1,2,3,4]}
 template: {$eval: 'a[2:10]'}
-error: true
+result: [3,4]
 ---
 title: array slice completely out of range
 context: {a: [1,2,3,4]}
 template: {$eval: 'a[8:10]'}
-error: true
+result: []
 ---
 title: array slice negative out of range
 context: {a: [1,2,3,4]}
 template: {$eval: 'a[2:-10]'}
-error: true
+result: []
 ---
 title: array slice negative range
 context: {a: [1,2,3,4]}
 template: {$eval: 'a[2:-3]'}
-error: true
+result: []
+---
+title: array slice reverse range
+context: {a: [1,2,3,4]}
+template: {$eval: 'a[3:2]'}
+result: []
 ---
 title: function min(contextValue, contextValue)
 context: {a: 1, b: 2}


### PR DESCRIPTION
@djmitche, consider this a bug report... I'm not entirely sure what the semantics here should be...
But I don't think these out-of-range slicing was tested before, so we probably didn't make a decision on what it should be... Ideas?

I'm thinking that `array[a:b]` should cause an error if `b > a`, or is there a good reason to have `myarray[2:-3]` to discard first two entries and ignore the last 3, but get an empty array if `myarray` is less than 6... ? What is a good choice between throwing an error and just returning an empty array?