### PR TITLE
str(array) shouldn't be allowed

### DIFF
--- a/specification.yml
+++ b/specification.yml
@@ -1380,70 +1380,65 @@ context: {}
 template: {$eval: 'len(1)'}
 error: true
 ---
-title: str (1)
-context: {key: 1}
+title: str(key) with number
+context: {key: 42}
 template: {$eval: 'str(key)'}
-result: '1'
+result: '42'
 ---
-title: str (2)
+title: str(42)
 context: {}
-template: {$eval: 'str(1)'}
-result: '1'
+template: {$eval: 'str(42)'}
+result: '42'
 ---
-title: str (3)
+title: str(key) with string
 context: {key: 'hello'}
 template: {$eval: 'str(key)'}
 result: 'hello'
 ---
-title: str (4)
+title: str("hello")
 context: {}
 template: {$eval: 'str("hello")'}
 result: 'hello'
 ---
-title: str (3)
-context: {key: 'hello'}
-template: {$eval: 'str(key)'}
-result: 'hello'
----
-title: str (4)
-context: {}
-template: {$eval: 'str("hello")'}
-result: 'hello'
----
-title: str (5)
+title: str(key) with bool
 context: {key: true}
 template: {$eval: 'str(key)'}
 result: 'true'
 ---
-title: str (6)
+title: str(true)
 context: {}
 template: {$eval: 'str(true)'}
 result: 'true'
 ---
-title: str (6)
-context: {x: null}
-template: {$eval: 'str(x)'}
-error: true
----
-title: str (7)
-context: {key: false}
-template: {$eval: 'str(key)'}
-result: 'false'
----
-title: str (8)
+title: str(false)
 context: {}
 template: {$eval: 'str(false)'}
 result: 'false'
 ---
-title: str (9)
+title: str(null)
+context: {x: null}
+template: {$eval: 'str(x)'}
+error: true
+---
+title: str(key) with array
 context: {key: [1, 2, 3]}
 template: {$eval: 'str(key)'}
-result: '1,2,3'
+error: true
 ---
-title: str (10)
+title: str([1, 2, 3])
 context: {}
 template: {$eval: 'str([1, 2, 3])'}
-result: '1,2,3'
+error: true
+---
+title: str({})
+context: {}
+template: {$eval: 'str({})'}
+error: true
+---
+title: str({a: 1})
+context: {}
+template: {$eval: 'str({a: 1})'}
+error: true
 ---
 title:    fromNow
 context:  {}


### PR DESCRIPTION
Currently we have `"${str([1,2,{}])}"` rendering as `"${str([1,2,{}])}"` and I'm pretty sure that's platform dependent...


Sorry, I fear this is just a bug report with test cases...

