### PR TITLE
Identifiers beginning with `in` are not allowed

### DIFF
--- a/jsone/interpreter.py
+++ b/jsone/interpreter.py
@@ -35,6 +35,11 @@ class ExpressionEvaluator(PrattParser):
         'number': '[0-9]+(?:\\.[0-9]+)?',
         'identifier': '[a-zA-Z_][a-zA-Z_0-9]*',
         'string': '\'[^\']*\'|"[^"]*"',
+        # avoid matching these as prefixes of identifiers e.g., `insinutations`
+        'true': 'true(?![a-zA-Z_0-9])',
+        'false': 'false(?![a-zA-Z_0-9])',
+        'in': 'in(?![a-zA-Z_0-9])',
+        'null': 'null(?![a-zA-Z_0-9])',
     }
     tokens = [
         '**', '+', '-', '*', '/', '[', ']', '.', '(', ')', '{', '}', ':', ',',

--- a/specification.yml
+++ b/specification.yml
@@ -1637,6 +1637,21 @@ title: function max(contextValue, value)
 context: {a: 1, b: 2}
 template: {$eval: 'max(a, 3)'}
 result: 3
+---
+title: identifier beginning with in
+context: {input: 6}
+template: {$eval: 'input + 1'}
+result: 7
+---
+title: identifier beginning with true / false
+context: {true_facts: true, false_lies: false}
+template: {$eval: 'true_facts || false_lies'}
+result: true
+---
+title: identifier beginning with null
+context: {null_hypothesis: "no difference"}
+template: {$eval: 'null_hypothesis'}
+result: "no difference"
 ################################################################################
 ---
 section: expression language - arithmetic

--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -326,6 +326,11 @@ module.exports = new PrattParser({
     number:     '[0-9]+(?:\\.[0-9]+)?',
     identifier: '[a-zA-Z_][a-zA-Z_0-9]*',
     string:     '\'[^\']*\'|"[^"]*"',
+    // avoid matching these as prefixes of identifiers e.g., `insinutations`
+    true: 'true(?![a-zA-Z_0-9])',
+    false: 'false(?![a-zA-Z_0-9])',
+    in: 'in(?![a-zA-Z_0-9])',
+    null: 'null(?![a-zA-Z_0-9])',
   },
   tokens: [
     '**', ...'+-*/[].(){}:,'.split(''),


### PR DESCRIPTION
```
jsone.prattparser.SyntaxError: Found in, expected !, (, +, -, [, false, identifier, null, number, string, true, {
```