### PR TITLE
Support a base value for $fromNow

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,14 +191,20 @@ result:   [1, 2, 3]
 ### `$fromNow`
 
 The `$fromNow` operator is a shorthand for the built-in function `fromNow`. It
-creates a JSON (ISO 8601) datestamp for a time relative to the current time.
-The offset is specified by a sequence of number/unit pairs in a string. For
-example:
+creates a JSON (ISO 8601) datestamp for a time relative to the current time or,
+if `from` is given, from that time.  The offset is specified by a sequence of
+number/unit pairs in a string. For example:
 
 ```yaml
 context:  {}
 template: {$fromNow: '2 days 1 hour'}
 result:   '2017-01-19T16:27:20.974Z'
+```
+
+```yaml
+context:  {}
+template: {$fromNow: '1 hour', from: '2017-01-19T16:27:20.974Z'}
+result:   '2017-01-19T17:27:20.974Z'
 ```
 
 The available units are `day`, `hour`, and `minute`, for all of which a plural
@@ -336,7 +342,7 @@ The expression language provides a laundry-list of built-in functions. Library
 users can easily add additional functions, or override the built-ins, as part
 of the context.
 
-* `fromNow(x)` -- JSON datestamp for a time relative to the current time
+* `fromNow(offset)` or `fromNow(offset, reference)` -- JSON datestamp for a time relative to the current time or, if given, the reference time
 * `min(a, b, ..)` -- the smallest of the arguments
 * `max(a, b, ..)` -- the largest of the arguments
 * `sqrt(x)`, `ceil(x)`, `floor(x)`, `abs(x)` -- mathematical functions

--- a/jsone/builtins.py
+++ b/jsone/builtins.py
@@ -108,7 +108,9 @@ def to_str(v):
         return str(v)
 
 
-builtin('fromNow', argument_tests=[is_string])(fromNow)
+@builtin('fromNow', variadic=is_string, minArgs=1)
+def fromNow_builtin(offset, reference=None):
+    return fromNow(offset, reference)
 
 @builtin('typeof', argument_tests=[anything])
 def typeof(v):

--- a/jsone/render.py
+++ b/jsone/render.py
@@ -94,9 +94,11 @@ def flattenDeep(template, context):
 @operator('$fromNow')
 def fromNow(template, context):
     offset = renderValue(template['$fromNow'], context)
+    reference = renderValue(template['from'], context) if 'from' in template else None
+
     if not isinstance(offset, string):
         raise JSONTemplateError("$fromnow expects a string")
-    return shared.fromNow(offset)
+    return shared.fromNow(offset, reference)
 
 
 @operator('$if')

--- a/jsone/shared.py
+++ b/jsone/shared.py
@@ -28,7 +28,7 @@ FROMNOW_RE = re.compile(''.join([
 ]))
 
 
-def fromNow(offset):
+def fromNow(offset, reference):
     # copied from taskcluster-client.py
     # We want to handle past dates as well as future
     future = True
@@ -72,7 +72,11 @@ def fromNow(offset):
         seconds=seconds,
     )
 
-    return stringDate(utcnow() + delta if future else utcnow() - delta)
+    if reference:
+        reference = datetime.datetime.strptime(reference, '%Y-%m-%dT%H:%M:%S.%fZ')
+    else:
+        reference = utcnow()
+    return stringDate(reference + delta if future else reference - delta)
 
 
 datefmt_re = re.compile(r'(\.[0-9]{3})[0-9]*(\+00:00)?')

--- a/specification.yml
+++ b/specification.yml
@@ -539,6 +539,11 @@ title:    fromNow with eval
 context:  {ttl: 24}
 template: {$fromNow: {$eval: 'str(ttl) + " hours"'}}
 result:   '2017-01-20T16:27:20.974Z'
+---
+title:    fromNow with reference
+context:  {now: '2019-01-01T01:00:00.123Z'}
+template: {$fromNow: '3 mo', from: {$eval: now}}
+result:   '2019-04-01T01:00:00.123Z'
 ################################################################################
 ---
 section:  $json
@@ -1461,6 +1466,11 @@ title:    fromNow - 2 days 3 hours
 context:  {}
 template: {$eval: fromNow("2 days 3 hours")}
 result:   '2017-01-21T19:27:20.974Z'
+---
+title:    fromNow with reference
+context:  {}
+template: {$eval: "fromNow('1 day', '2017-01-01T01:00:00.123Z')"}
+result:   '2017-01-02T01:00:00.123Z'
 ---
 title:    fromNow - TypeError
 context:  {}

--- a/src/builtins.js
+++ b/src/builtins.js
@@ -98,8 +98,9 @@ define('len', builtins, {
 
 // Miscellaneous
 define('fromNow', builtins, {
-  argumentTests: ['string'],
-  invoke: str => fromNow(str),
+  variadic: 'string',
+  minArgs: 1,
+  invoke: (str, reference) => fromNow(str, reference),
 });
 
 define('typeof', builtins, {

--- a/src/from-now.js
+++ b/src/from-now.js
@@ -34,12 +34,18 @@ var parseTime = function(str) {
 };
 
 // Render timespan fromNow as JSON timestamp
-module.exports = (timespan = '', reference = new Date()) => {
+module.exports = (timespan = '', reference) => {
   let offset = parseTime(timespan);
 
   // represent months and years as 30 and 365 days, respectively
   offset.days += 30 * offset.months;
   offset.days += 365 * offset.years;
+
+  if (reference) {
+    reference = new Date(reference);
+  } else {
+    reference = new Date();
+  }
 
   var retval = new Date(
     reference.getTime()

--- a/src/index.js
+++ b/src/index.js
@@ -80,10 +80,14 @@ operators.$flattenDeep = (template, context) => {
 
 operators.$fromNow = (template, context) => {
   let value = render(template['$fromNow'], context);
+  let reference;
+  if (template['from']) {
+    reference = render(template['from'], context);
+  }
   if (!isString(value)) {
     throw jsonTemplateError('$fromNow can evaluate string expressions only\n', template);
   }
-  return fromNow(value);
+  return fromNow(value, reference);
 };
 
 operators.$if = (template, context) => {


### PR DESCRIPTION
To replace
```yaml
tasks:
  - task:
      created: '{{now}}'
      deadline: '{{#from_now}}1 day{{/from_now}}'
      expires: '{{#from_now}}365 day{{/from_now}}'
```
and have those values be reproducible, we need to be able to use the same base time:
```yaml
$let:
  now: {$fromNow: '0 days'}
in:
  tasks:
   - task:
     created: {$fromNow: '0 days', from: {$eval: now}}
     deadline: {$fromNow: '1 day', from: {$eval: now}}
     expires: {$fromNow: '1 year', from: {$eval: now}}
```