### PR TITLE
Python: built-in functions get a list of arguments

### DIFF
--- a/jsone/builtins.py
+++ b/jsone/builtins.py
@@ -12,7 +12,7 @@ def builtin(name, variadic=None, argument_tests=None, minArgs=None):
         def bad(reason=None):
             raise ExpressionError((reason or 'invalid arguments to {}').format(name))
         if variadic:
-            def invoke(args):
+            def invoke(*args):
                 if minArgs:
                     if len(args) < minArgs:
                         bad("too few arguments to {}")
@@ -22,7 +22,7 @@ def builtin(name, variadic=None, argument_tests=None, minArgs=None):
                 return fn(*args)
 
         elif argument_tests:
-            def invoke(args):
+            def invoke(*args):
                 if len(args) != len(argument_tests):
                     bad()
                 for t, arg in zip(argument_tests, args):
@@ -31,7 +31,7 @@ def builtin(name, variadic=None, argument_tests=None, minArgs=None):
                 return fn(*args)
 
         else:
-            def invoke(args):
+            def invoke(*args):
                 return fn(*args)
 
         builtins[name] = invoke

--- a/jsone/interpreter.py
+++ b/jsone/interpreter.py
@@ -189,7 +189,7 @@ class ExpressionEvaluator(PrattParser):
         if not callable(left):
             raise ExpressionError('function call', 'callable')
         args = parseList(pc, ',', ')')
-        return left(args)
+        return left(*args)
 
     @infix('==', '!=', '||', '&&')
     def equality_and_logic(self, left, token, pc):

--- a/test/misc_test.js
+++ b/test/misc_test.js
@@ -1,0 +1,10 @@
+var assume = require('assume');
+var jsone = require('../src/');
+
+suite('misc', function() {
+  test('custom builtin', function() {
+    let my_builtin = (x, y) => Math.sqrt(x * x + y * y);
+
+    assume(jsone({$eval: 'my_builtin(3, 4)'}, {my_builtin})).eql(5);
+  });
+});

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -1,0 +1,11 @@
+from __future__ import absolute_import, print_function, unicode_literals
+
+import math
+from nose.tools import eq_
+from jsone import render, JSONTemplateError
+
+
+def test_custom_builtin():
+    def my_builtin(x, y):
+        return math.sqrt(x ** 2 + y ** 2)
+    eq_(render({'$eval': 'my_builtin(3, 4)'}, {'my_builtin': my_builtin}), 5)


### PR DESCRIPTION
```python
def as_slugid(name):
  print(name)
```
gives `['decision']` for `'${as_slugid("decision")}'`.