### PR TITLE
Need better context-finding for error messages

### DIFF
--- a/jsone/__init__.py
+++ b/jsone/__init__.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 import re
 from .render import renderValue
-from .shared import JSONTemplateError, DeleteMarker
+from .shared import JSONTemplateError, DeleteMarker, TemplateError
 from .builtins import builtins
 
 _context_re = re.compile(r'[a-zA-Z_][a-zA-Z0-9_]*$')
@@ -10,7 +10,7 @@ _context_re = re.compile(r'[a-zA-Z_][a-zA-Z0-9_]*$')
 
 def render(template, context):
     if not all(_context_re.match(c) for c in context):
-        raise JSONTemplateError('top level keys of context must follow '
+        raise TemplateError('top level keys of context must follow '
                                 '/[a-zA-Z_][a-zA-Z0-9_]*/')
     full_context = builtins.copy()
     full_context.update(context)

--- a/jsone/builtins.py
+++ b/jsone/builtins.py
@@ -1,16 +1,17 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 import math
-from .interpreter import ExpressionError
-from .shared import string, fromNow
+from .shared import string, fromNow, JSONTemplateError
 
 builtins = {}
 
+class BuiltinError(JSONTemplateError):
+    pass
 
 def builtin(name, variadic=None, argument_tests=None, minArgs=None):
     def wrap(fn):
         def bad(reason=None):
-            raise ExpressionError((reason or 'invalid arguments to {}').format(name))
+            raise BuiltinError((reason or 'invalid arguments to {}').format(name))
         if variadic:
             def invoke(*args):
                 if minArgs:

--- a/jsone/interpreter.py
+++ b/jsone/interpreter.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 from .prattparser import PrattParser, infix, prefix
-from .shared import JSONTemplateError, string
+from .shared import TemplateError, string
 import operator
 import json
 
@@ -21,7 +21,7 @@ OPERATORS = {
 }
 
 
-class ExpressionError(JSONTemplateError):
+class ExpressionError(TemplateError):
 
     @classmethod
     def expectation(cls, operator, expected):

--- a/jsone/interpreter.py
+++ b/jsone/interpreter.py
@@ -21,11 +21,8 @@ OPERATORS = {
 }
 
 
-class ExpressionError(TemplateError):
-
-    @classmethod
-    def expectation(cls, operator, expected):
-        return cls('{} expected {}'.format(operator, expected))
+def expectationError(operator, expected):
+    return TemplateError('{} expected {}'.format(operator, expected))
 
 
 class ExpressionEvaluator(PrattParser):
@@ -67,7 +64,7 @@ class ExpressionEvaluator(PrattParser):
 
     def parse(self, expression):
         if not isinstance(expression, string):
-            raise ExpressionError('expression to be evaluated must be a string')
+            raise TemplateError('expression to be evaluated must be a string')
         return super(ExpressionEvaluator, self).parse(expression)
 
     @prefix('number')
@@ -83,14 +80,14 @@ class ExpressionEvaluator(PrattParser):
     def uminus(self, token, pc):
         v = pc.parse('unary')
         if not isNumber(v):
-            raise ExpressionError.expectation('unary -', 'number')
+            raise expectationError('unary -', 'number')
         return -v
 
     @prefix("+")
     def uplus(self, token, pc):
         v = pc.parse('unary')
         if not isNumber(v):
-            raise ExpressionError.expectation('unary +', 'number')
+            raise expectationError('unary +', 'number')
         return v
 
     @prefix("identifier")
@@ -98,7 +95,7 @@ class ExpressionEvaluator(PrattParser):
         try:
             return self.context[token.value]
         except KeyError:
-            raise ExpressionError('no context value named "{}"'.format(token.value))
+            raise TemplateError('no context value named "{}"'.format(token.value))
 
     @prefix("null")
     def null(self, token, pc):
@@ -133,23 +130,23 @@ class ExpressionEvaluator(PrattParser):
     @infix("+")
     def plus(self, left, token, pc):
         if not isinstance(left, (string, int, float)) or isinstance(left, bool):
-            raise ExpressionError.expectation('+', 'number or string')
+            raise expectationError('+', 'number or string')
         right = pc.parse(token.kind)
         if not isinstance(right, (string, int, float)) or isinstance(right, bool):
-            raise ExpressionError.expectation('+', 'number or string')
+            raise expectationError('+', 'number or string')
         if type(right) != type(left) and \
                 (isinstance(left, string) or isinstance(right, string)):
-            raise ExpressionError.expectation('+', 'matching types')
+            raise expectationError('+', 'matching types')
         return left + right
 
     @infix('-', '*', '/', '**')
     def arith(self, left, token, pc):
         op = token.kind
         if not isNumber(left):
-            raise ExpressionError.expectation(op, 'number')
+            raise expectationError(op, 'number')
         right = pc.parse({'**': '**-right-associative'}.get(op))
         if not isNumber(right):
-            raise ExpressionError.expectation(op, 'number')
+            raise expectationError(op, 'number')
         return OPERATORS[op](left, right)
 
     @infix("[")
@@ -177,17 +174,17 @@ class ExpressionEvaluator(PrattParser):
     @infix(".")
     def property_dot(self, left, token, pc):
         if not isinstance(left, dict):
-            raise ExpressionError.expectation('.', 'object')
+            raise expectationError('.', 'object')
         k = pc.require('identifier').value
         try:
             return left[k]
         except KeyError:
-            raise ExpressionError('{} not found in {}'.format(k, json.dumps(left)))
+            raise TemplateError('{} not found in {}'.format(k, json.dumps(left)))
 
     @infix("(")
     def function_call(self, left, token, pc):
         if not callable(left):
-            raise ExpressionError('function call', 'callable')
+            raise TemplateError('function call', 'callable')
         args = parseList(pc, ',', ')')
         return left(*args)
 
@@ -203,7 +200,7 @@ class ExpressionEvaluator(PrattParser):
         right = pc.parse(op)
         if type(left) != type(right) or \
                 not (isinstance(left, (int, float, string)) and not isinstance(left, bool)):
-            raise ExpressionError.expectation(op, 'matching types')
+            raise expectationError(op, 'matching types')
         return OPERATORS[op](left, right)
 
     @infix("in")
@@ -211,16 +208,16 @@ class ExpressionEvaluator(PrattParser):
         right = pc.parse(token.kind)
         if isinstance(right, dict):
             if not isinstance(left, string):
-                raise ExpressionError.expectation('in-object', 'string on left side')
+                raise expectationError('in-object', 'string on left side')
         elif isinstance(right, string):
             if not isinstance(left, string):
-                raise ExpressionError.expectation('in-string', 'string on left side')
+                raise expectationError('in-string', 'string on left side')
         elif not isinstance(right, list):
-            raise ExpressionError.expectation('in', 'Array, string, or object on right side')
+            raise expectationError('in', 'Array, string, or object on right side')
         try:
             return left in right
         except TypeError:
-            raise ExpressionError.expectation('in', 'scalar value, collection')
+            raise expectationError('in', 'scalar value, collection')
 
 
 def isNumber(v):
@@ -268,22 +265,22 @@ def accessProperty(value, a, b, is_interval):
             try:
                 return value[a:b]
             except TypeError:
-                raise ExpressionError.expectation('[..]', 'integer')
+                raise expectationError('[..]', 'integer')
         else:
             try:
                 return value[a]
             except IndexError:
-                raise ExpressionError('index out of bounds')
+                raise TemplateError('index out of bounds')
             except TypeError:
-                raise ExpressionError.expectation('[..]', 'integer')
+                raise expectationError('[..]', 'integer')
 
     if not isinstance(value, dict):
-        raise ExpressionError.expectation('[..]', 'object, array, or string')
+        raise expectationError('[..]', 'object, array, or string')
     if not isinstance(a, string):
-        raise ExpressionError.expectation('[..]', 'string index')
+        raise expectationError('[..]', 'string index')
 
     try:
         return value[a]
     except KeyError:
         return None
-        #raise ExpressionError('{} not found in {}'.format(a, json.dumps(value)))
+        #raise TemplateError('{} not found in {}'.format(a, json.dumps(value)))

--- a/jsone/prattparser.py
+++ b/jsone/prattparser.py
@@ -2,11 +2,11 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 import re
 from collections import namedtuple
-from .shared import JSONTemplateError
+from .shared import TemplateError
 from .six import with_metaclass, viewitems
 
 
-class SyntaxError(JSONTemplateError):
+class SyntaxError(TemplateError):
 
     @classmethod
     def unexpected(cls, got, exp):

--- a/jsone/render.py
+++ b/jsone/render.py
@@ -38,7 +38,8 @@ def interpolate(string, context):
             string = string[mo.end():]
             parsed, offset = evaluator.parseUntilTerminator(string, '}')
             if isinstance(parsed, (list, dict)):
-                raise TemplateError('cannot interpolate array/object: ' + string[:offset])
+                raise TemplateError(
+                    "interpolation of '{}' produced an array or object".format(string[:offset]))
             result.append(builtins.to_str(parsed))
             string = string[offset + 1:]
         else:  # found `$${`

--- a/jsone/render.py
+++ b/jsone/render.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 import re
 import json as json
-from .shared import JSONTemplateError, DeleteMarker, string
+from .shared import TemplateError, DeleteMarker, string
 from . import shared
 from . import builtins
 from .interpreter import ExpressionEvaluator
@@ -38,7 +38,7 @@ def interpolate(string, context):
             string = string[mo.end():]
             parsed, offset = evaluator.parseUntilTerminator(string, '}')
             if isinstance(parsed, (list, dict)):
-                raise JSONTemplateError('cannot interpolate array/object: ' + string)
+                raise TemplateError('cannot interpolate array/object: ' + string[:offset])
             result.append(builtins.to_str(parsed))
             string = string[offset + 1:]
         else:  # found `$${`
@@ -62,7 +62,7 @@ def eval(template, context):
 def flatten(template, context):
     value = renderValue(template['$flatten'], context)
     if not isinstance(value, list):
-        raise JSONTemplateError('$flatten value must evaluate to an array of arrays')
+        raise TemplateError('$flatten value must evaluate to an array of arrays')
 
     def gen():
         for e in value:
@@ -78,7 +78,7 @@ def flatten(template, context):
 def flattenDeep(template, context):
     value = renderValue(template['$flattenDeep'], context)
     if not isinstance(value, list):
-        raise JSONTemplateError('$flatten value must evaluate to an array')
+        raise TemplateError('$flatten value must evaluate to an array')
 
     def gen(value):
         if isinstance(value, list):
@@ -97,7 +97,7 @@ def fromNow(template, context):
     reference = renderValue(template['from'], context) if 'from' in template else None
 
     if not isinstance(offset, string):
-        raise JSONTemplateError("$fromnow expects a string")
+        raise TemplateError("$fromnow expects a string")
     return shared.fromNow(offset, reference)
 
 
@@ -124,13 +124,13 @@ def jsonConstruct(template, context):
 def let(template, context):
     variables = renderValue(template['$let'], context)
     if not isinstance(variables, dict):
-        raise JSONTemplateError("$let value must evaluate to an object")
+        raise TemplateError("$let value must evaluate to an object")
     subcontext = context.copy()
     subcontext.update(variables)
     try:
         in_expression = template['in']
     except KeyError:
-        raise JSONTemplateError("$let operator requires an `in` clause")
+        raise TemplateError("$let operator requires an `in` clause")
     return renderValue(in_expression, subcontext)
 
 
@@ -138,13 +138,13 @@ def let(template, context):
 def map(template, context):
     value = renderValue(template['$map'], context)
     if not isinstance(value, list) and not isinstance(value, dict):
-        raise JSONTemplateError("$map value must evaluate to an array or object")
+        raise TemplateError("$map value must evaluate to an array or object")
 
     is_obj = isinstance(value, dict)
 
     each_keys = [k for k in template if k.startswith('each(')]
     if len(each_keys) != 1:
-        raise JSONTemplateError("$map requires exactly one other property, each(..)")
+        raise TemplateError("$map requires exactly one other property, each(..)")
     each_key = each_keys[0]
     each_var = each_key[5:-1]
     each_template = template[each_key]
@@ -173,7 +173,7 @@ def map(template, context):
 def merge(template, context):
     value = renderValue(template['$merge'], context)
     if not isinstance(value, list) or not all(isinstance(e, dict) for e in value):
-        raise JSONTemplateError("$reverse value must evaluate to an array of objects")
+        raise TemplateError("$reverse value must evaluate to an array of objects")
     v = dict()
     for e in value:
         v.update(e)
@@ -184,7 +184,7 @@ def merge(template, context):
 def reverse(template, context):
     value = renderValue(template['$reverse'], context)
     if not isinstance(value, list):
-        raise JSONTemplateError("$reverse value must evaluate to an array")
+        raise TemplateError("$reverse value must evaluate to an array")
     return list(reversed(value))
 
 
@@ -192,7 +192,7 @@ def reverse(template, context):
 def sort(template, context):
     value = renderValue(template['$sort'], context)
     if not isinstance(value, list):
-        raise JSONTemplateError("$sort value must evaluate to an array")
+        raise TemplateError("$sort value must evaluate to an array")
 
     # handle by(..) if given, applying the schwartzian transform
     by_keys = [k for k in template if k.startswith('by(')]
@@ -210,7 +210,7 @@ def sort(template, context):
     elif len(by_keys) == 0:
         to_sort = [(e, e) for e in value]
     else:
-        raise JSONTemplateError('only one by(..) is allowed')
+        raise TemplateError('only one by(..) is allowed')
 
     # check types
     try:
@@ -218,9 +218,9 @@ def sort(template, context):
     except IndexError:
         return []
     if eltype in (list, dict, bool, type(None)):
-        raise JSONTemplateError('$sort values must be sortable')
+        raise TemplateError('$sort values must be sortable')
     if not all(isinstance(e[0], eltype) for e in to_sort):
-        raise JSONTemplateError('$sorted values must all have the same type')
+        raise TemplateError('$sorted values must all have the same type')
 
     # unzip the schwartzian transform
     return list(e[1] for e in sorted(to_sort))
@@ -234,7 +234,7 @@ def renderValue(template, context):
         matches = [k for k in template if k in operators]
         if matches:
             if len(matches) > 1:
-                raise JSONTemplateError("only one operator allowed")
+                raise TemplateError("only one operator allowed")
             return operators[matches[0]](template, context)
 
         def updated():

--- a/jsone/render.py
+++ b/jsone/render.py
@@ -63,7 +63,7 @@ def eval(template, context):
 def flatten(template, context):
     value = renderValue(template['$flatten'], context)
     if not isinstance(value, list):
-        raise TemplateError('$flatten value must evaluate to an array of arrays')
+        raise TemplateError('$flatten value must evaluate to an array')
 
     def gen():
         for e in value:
@@ -79,7 +79,7 @@ def flatten(template, context):
 def flattenDeep(template, context):
     value = renderValue(template['$flattenDeep'], context)
     if not isinstance(value, list):
-        raise TemplateError('$flatten value must evaluate to an array')
+        raise TemplateError('$flattenDeep value must evaluate to an array')
 
     def gen(value):
         if isinstance(value, list):
@@ -98,7 +98,7 @@ def fromNow(template, context):
     reference = renderValue(template['from'], context) if 'from' in template else None
 
     if not isinstance(offset, string):
-        raise TemplateError("$fromnow expects a string")
+        raise TemplateError("$fromNow expects a string")
     return shared.fromNow(offset, reference)
 
 
@@ -174,7 +174,7 @@ def map(template, context):
 def merge(template, context):
     value = renderValue(template['$merge'], context)
     if not isinstance(value, list) or not all(isinstance(e, dict) for e in value):
-        raise TemplateError("$reverse value must evaluate to an array of objects")
+        raise TemplateError("$merge value must evaluate to an array of objects")
     v = dict()
     for e in value:
         v.update(e)

--- a/jsone/shared.py
+++ b/jsone/shared.py
@@ -12,8 +12,19 @@ class DeleteMarker:
 
 
 class JSONTemplateError(Exception):
+    def __init__(self, message):
+        super(JSONTemplateError, self).__init__(message)
+        self.location = []
+
+    def add_location(self, loc):
+        self.location.insert(0, loc)
+
     def __str__(self):
-        return "{}: {}".format(self.__class__.__name__, self.args[0])
+        location = ' at template' + ''.join(self.location)
+        return "{}{}: {}".format(
+            self.__class__.__name__,
+            location if self.location else '',
+            self.args[0])
 
 
 class TemplateError(JSONTemplateError):

--- a/jsone/shared.py
+++ b/jsone/shared.py
@@ -12,6 +12,11 @@ class DeleteMarker:
 
 
 class JSONTemplateError(Exception):
+    def __str__(self):
+        return "{}: {}".format(self.__class__.__name__, self.args[0])
+
+
+class TemplateError(JSONTemplateError):
     pass
 
 

--- a/package.json
+++ b/package.json
@@ -18,9 +18,7 @@
   },
   "author": "",
   "license": "MPL-2.0",
-  "dependencies": {
-    "es6-error": "^4.0.1"
-  },
+  "dependencies": {},
   "devDependencies": {
     "assume": "^1.4.1",
     "browserify": "^14.4.0",

--- a/specification.yml
+++ b/specification.yml
@@ -83,12 +83,12 @@ result:   {message: 'tricky }}}}'}
 title:    can't interpolate arrays
 context:  {key: [1,2,3]}
 template: {message: 'hello ${key}'}
-error:    "TemplateError: interpolation of 'key' produced an array or object"
+error:    "TemplateError at template.message: interpolation of 'key' produced an array or object"
 ---
 title:    can't interpolate objects
 context:  {key: {}}
 template: 'hello ${key}'
-error:    true
+error:    "TemplateError: interpolation of 'key' produced an array or object"
 ---
 title:    booleans interpolate
 context:  {t: true, f: false}
@@ -4690,3 +4690,8 @@ title: 'Infix >= type error'
 context: {}
 template: {$eval: '3 >= "hello"'}
 error: true
+---
+title: 'Nested error has appropriate message'
+context: {}
+template: {foo: [1, {"123": [{$eval: 10}]}]}
+error: 'TemplateError at template.foo[1]["123"][0]: expression to be evaluated must be a string'

--- a/specification.yml
+++ b/specification.yml
@@ -83,7 +83,7 @@ result:   {message: 'tricky }}}}'}
 title:    can't interpolate arrays
 context:  {key: [1,2,3]}
 template: {message: 'hello ${key}'}
-error:    true
+error:    "TemplateError: cannot interpolate array/object: key"
 ---
 title:    can't interpolate objects
 context:  {key: {}}

--- a/specification.yml
+++ b/specification.yml
@@ -105,10 +105,10 @@ context:  {nothing: null}
 template: 'big pile of ${nothing}'
 result:   'big pile of null'
 ---
-title: invalid context (2)
+title: invalid context
 context: {'a b c': 1}
 template: {}
-error: true
+error: 'TemplateError: top level keys of context must follow /[a-zA-Z_][a-zA-Z0-9_]*/'
 ################################################################################
 ---
 section:  $if operator

--- a/specification.yml
+++ b/specification.yml
@@ -83,7 +83,7 @@ result:   {message: 'tricky }}}}'}
 title:    can't interpolate arrays
 context:  {key: [1,2,3]}
 template: {message: 'hello ${key}'}
-error:    "TemplateError: cannot interpolate array/object: key"
+error:    "TemplateError: interpolation of 'key' produced an array or object"
 ---
 title:    can't interpolate objects
 context:  {key: {}}

--- a/specification.yml
+++ b/specification.yml
@@ -352,12 +352,12 @@ result:   [1, 2, 3]
 title:    flatten null
 context:  {}
 template: {$flatten: null}
-error:    true
+error:    'TemplateError: $flatten value must evaluate to an array'
 ---
 title:    flatten an object
 context:  {}
 template: {$flatten: {a: 1, b: 2}}
-error:    true
+error:    'TemplateError: $flatten value must evaluate to an array'
 ---
 title:    flatten an array of strings
 context:  {}
@@ -405,12 +405,12 @@ result:   []
 title:    flattenDeep null
 context:  {}
 template: {$flattenDeep: null}
-error:    true
+error:    'TemplateError: $flattenDeep value must evaluate to an array'
 ---
 title:    flattenDeep an object
 context:  {}
 template: {$flattenDeep: {a: 1, b: 2}}
-error:    true
+error:    'TemplateError: $flattenDeep value must evaluate to an array'
 ---
 title:    flattenDeep an array of strings
 context:  {}
@@ -533,7 +533,7 @@ result:   '2018-01-19T16:27:20.974Z'
 title:    fromNow of non-string
 context:  {}
 template: {$fromNow: 13}
-error:    true
+error:    'TemplateError: $fromNow expects a string'
 ---
 title:    fromNow with eval
 context:  {ttl: 24}
@@ -612,17 +612,17 @@ result:   43
 title:    let without in
 template: {$let: {x: 1, y: 2}, a: {$eval: "x + y"}}
 context:  {}
-error:    true
+error:    'TemplateError: $let operator requires an `in` clause'
 ---
 title:    let array
 template: {$let: [1, 2], in: {$eval: "1 + 2"}}
 context:  {}
-error:    true
+error:    'TemplateError: $let value must evaluate to an object'
 ---
 title:    let null
 template: {$let: null, in: {$eval: "1 + 2"}}
 context:  {}
-error:    true
+error:    'TemplateError: $let value must evaluate to an object'
 ################################################################################
 ---
 section:  $map
@@ -717,21 +717,21 @@ context:  {}
 template:
   $map: "a, b, c"
   each(y): {$eval: 'y.k'}
-error: true # can't do map on non-arrays
+error: 'TemplateError: $map value must evaluate to an array or object'
 ---
 title:    $map requires an array, not number
 context:  {}
 template:
   $map: 10.1
   each(y): {$eval: 'y.k'}
-error: true # can't do map on non-arrays
+error: 'TemplateError: $map value must evaluate to an array or object'
 ---
 title:    $map requires an array, not null
 context:  {}
 template:
   $map: null
   each(y): {$eval: 'y.k'}
-error: true # can't do map on non-arrays
+error: 'TemplateError: $map value must evaluate to an array or object'
 ################################################################################
 ---
 section:  $merge
@@ -759,12 +759,12 @@ result:   {}
 title:    merge null
 context:  {}
 template: {$merge: null}
-error:    true
+error: 'TemplateError: $merge value must evaluate to an array of objects'
 ---
 title: $merge [null]
 template: {$merge: [null]}
 context: {}
-error: true
+error: 'TemplateError: $merge value must evaluate to an array of objects'
 ################################################################################
 ---
 section:  $sort

--- a/src/error.js
+++ b/src/error.js
@@ -1,6 +1,4 @@
-var ExtendableError = require('es6-error');
-
-class JSONTemplateError extends ExtendableError {
+class JSONTemplateError extends Error {
   constructor(message) {
     super(message);
     this.location = [];

--- a/src/error.js
+++ b/src/error.js
@@ -1,16 +1,33 @@
 var ExtendableError = require('es6-error');
 
-class SyntaxError extends ExtendableError {
-  constructor(message, {start, end}) {
+class JSONTemplateError extends ExtendableError {
+  constructor(message) {
     super(message);
-    this.name = 'SyntaxError';
-    this.message = message;
-    this.start = start;
-    this.end = end;
+    this.location = [];
+  }
+
+  add_location(loc) {
+    this.location.unshift(loc);
+  }
+
+  toString() {
+    if (this.location.length) {
+      return `${this.name} at template${this.location.join('')}: ${this.message}`;
+    } else {
+      return `${this.name}: ${this.message}`;
+    }
   }
 }
 
-class BaseError extends ExtendableError {
+class SyntaxError extends JSONTemplateError {
+  constructor(message) {
+    super(message);
+    this.message = message;
+    this.name = 'SyntaxError';
+  }
+}
+
+class BaseError extends JSONTemplateError {
   constructor(message) {
     super(message);
     this.message = message;
@@ -39,4 +56,4 @@ class BuiltinError extends BaseError {
   }
 }
 
-module.exports = {SyntaxError, InterpreterError, TemplateError, BuiltinError};
+module.exports = {JSONTemplateError, SyntaxError, InterpreterError, TemplateError, BuiltinError};

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,8 @@ let interpolate = (string, context) => {
     if (remaining[offset+1] != '$') {
       let v = interpreter.parseUntilTerminator(remaining.slice(offset), 2, '}', context);
       if (isArray(v.result) || isObject(v.result)) {
-        throw new TemplateError('cannot interpolate array/object: ' + string);
+        throw new TemplateError('cannot interpolate array/object: '
+            + remaining.slice(offset + 2, offset + v.offset));
       }
 
       // toString renders null as an empty string, which is not what we want

--- a/src/index.js
+++ b/src/index.js
@@ -281,9 +281,11 @@ let render = (template, context) => {
 };
 
 module.exports = (template, context = {}) => {
-  let test = Object.keys(context).every(v => /^[a-zA-Z_][a-zA-Z0-9_]*$/.exec(v)[0]);
+  let test = Object.keys(context).every(v => /^[a-zA-Z_][a-zA-Z0-9_]*$/.test(v));
+  if (!test) {
+    throw new TemplateError('top level keys of context must follow /[a-zA-Z_][a-zA-Z0-9_]*/');
+  }
   context = Object.assign({}, builtins, context);
-  assert(test, 'top level keys of context must follow /[a-zA-Z_][a-zA-Z0-9_]*/');
   let result = render(template, context);
   if (result === deleteMarker) {
     return null;

--- a/src/index.js
+++ b/src/index.js
@@ -25,8 +25,8 @@ let interpolate = (string, context) => {
     if (remaining[offset+1] != '$') {
       let v = interpreter.parseUntilTerminator(remaining.slice(offset), 2, '}', context);
       if (isArray(v.result) || isObject(v.result)) {
-        throw new TemplateError('cannot interpolate array/object: '
-            + remaining.slice(offset + 2, offset + v.offset));
+        let input = remaining.slice(offset + 2, offset + v.offset);
+        throw new TemplateError(`interpolation of '${input}' produced an array or object`);
       }
 
       // toString renders null as an empty string, which is not what we want

--- a/src/prattparser.js
+++ b/src/prattparser.js
@@ -5,7 +5,8 @@
 
 var Tokenizer = require('./tokenizer');
 var assert = require('assert');
-var {SyntaxError} = require('./error');
+var {isString} = require('./type-utils');
+var {SyntaxError, TemplateError} = require('./error');
 
 let syntaxRuleError = (token, expects) => new SyntaxError(`Found '${token.value}' expected '${expects}'`, token);
 
@@ -41,6 +42,9 @@ class PrattParser {
   }
 
   parse(source, context = {}, offset = 0) {
+    if (!isString(source)) {
+      throw new TemplateError('expression to be evaluated must be a string');
+    }
     let ctx = new Context(this, source, context, offset);
     let result = ctx.parse();
     let next = ctx.attempt();

--- a/test/specification_test.js
+++ b/test/specification_test.js
@@ -35,6 +35,11 @@ suite('json-e', () => {
           if (!c.error) {
             throw err;
           }
+          if (c.error === true) {  // no specific expectation
+            return;
+          }
+          err = err.toString();
+          assume(err).eql(c.error);
           return;
         }
         assert(!c.error, 'Expected an error');

--- a/test/test_prattparser.py
+++ b/test/test_prattparser.py
@@ -101,7 +101,7 @@ def test_parser():
         try:
             parser.parse(input)
         except JSONTemplateError as exc:
-            eq_(str(exc), message)
+            eq_(str(exc), "SyntaxError: " + message)
 
     yield fail, 'x', 'Unexpected input: \'x\''
     yield fail, '11', 'Found number, expected *, +, -'

--- a/test/test_specification.py
+++ b/test/test_specification.py
@@ -4,6 +4,7 @@ import os
 import unittest
 import yaml
 import jsone.shared
+from nose.tools import eq_
 
 TEST_DATE = dateutil.parser.parse('2017-01-19T16:27:20.974Z')
 
@@ -28,6 +29,10 @@ def test():
                 exc = e
             if 'error' in spec:
                 assert exc, "expected exception"
+                expected = spec['error']
+                if expected is True:  # no specific expectation
+                    return
+                eq_(str(exc), expected)
             else:
                 assert not exc
                 assert res == spec['result'], \

--- a/yarn.lock
+++ b/yarn.lock
@@ -599,10 +599,6 @@ es5-ext@^0.10.14, es5-ext@^0.10.9, es5-ext@~0.10.14:
     es6-iterator "2"
     es6-symbol "~3.1"
 
-es6-error@^4.0.1:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/es6-error/-/es6-error-4.0.2.tgz#eec5c726eacef51b7f6b73c20db6e1b13b069c98"
-
 es6-iterator@2, es6-iterator@^2.0.1, es6-iterator@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.1.tgz#8e319c9f0453bf575d374940a655920e59ca5512"


### PR DESCRIPTION
```
ExpressionError: no context value named "cron"
```

gee, thanks.  Where might that have appeared?

Something like

```
ExpressionError: no context value named cron in tasks[0].payload.command[2] offset 7-11
```

would be a lot better.  This could probably be assembled only as necessary by nested exception handlers, each adding a prefix to the JSON path.

We'll also need some way of testing error messages..