### PR TITLE
Fix time in place when evaluating

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,19 +494,21 @@ Function calls are made with the usual `fn(arg1, arg2)` syntax. Functions are
 not JSON data, so they cannot be created in JSON-e, but they can be provided as
 built-ins or in the context and called from JSON-e.
 
-#### Built-In Functions
+#### Built-In Functions and Variables
 
-The expression language provides a laundry-list of built-in functions. Library
-users can easily add additional functions, or override the built-ins, as part
+The expression language provides a laundry-list of built-in functions/variables. Library
+users can easily add additional functions/variables, or override the built-ins, as part
 of the context.
 
 * `fromNow(offset)` or `fromNow(offset, reference)` -- JSON datestamp for a time relative to the current time or, if given, the reference time
+* `now` -- the datestamp at the start of evaluation of the template. This is used implicitly as `from` in all fromNow calls. Override to set a different time.
 * `min(a, b, ..)` -- the smallest of the arguments
 * `max(a, b, ..)` -- the largest of the arguments
 * `sqrt(x)`, `ceil(x)`, `floor(x)`, `abs(x)` -- mathematical functions
 * `lowercase(s)`, `uppercase(s)` -- convert string case
 * `str(x)` -- convert string, number, boolean, or array to string
 * `len(x)` -- length of a string or array
+
 
 # Development and testing
 

--- a/jsone/__init__.py
+++ b/jsone/__init__.py
@@ -1,9 +1,10 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
+import datetime
 import re
 from .render import renderValue
 from .shared import JSONTemplateError, DeleteMarker, TemplateError
-from .builtins import builtins
+from . import builtins
 
 _context_re = re.compile(r'[a-zA-Z_][a-zA-Z0-9_]*$')
 
@@ -12,7 +13,8 @@ def render(template, context):
     if not all(_context_re.match(c) for c in context):
         raise TemplateError('top level keys of context must follow '
                                 '/[a-zA-Z_][a-zA-Z0-9_]*/')
-    full_context = builtins.copy()
+    full_context = {'now': datetime.datetime.utcnow()}
+    full_context.update(builtins.build(full_context))
     full_context.update(context)
     rv = renderValue(template, full_context)
     if rv is DeleteMarker:

--- a/jsone/builtins.py
+++ b/jsone/builtins.py
@@ -3,129 +3,132 @@ from __future__ import absolute_import, print_function, unicode_literals
 import math
 from .shared import string, fromNow, JSONTemplateError
 
-builtins = {}
 
 class BuiltinError(JSONTemplateError):
     pass
 
-def builtin(name, variadic=None, argument_tests=None, minArgs=None):
-    def wrap(fn):
-        def bad(reason=None):
-            raise BuiltinError((reason or 'invalid arguments to {}').format(name))
-        if variadic:
-            def invoke(*args):
-                if minArgs:
-                    if len(args) < minArgs:
-                        bad("too few arguments to {}")
-                for arg in args:
-                    if not variadic(arg):
-                        bad()
-                return fn(*args)
+def build(context):
+    builtins = {}
+    def builtin(name, variadic=None, argument_tests=None, minArgs=None):
+        def wrap(fn):
+            def bad(reason=None):
+                raise BuiltinError((reason or 'invalid arguments to {}').format(name))
+            if variadic:
+                def invoke(*args):
+                    if minArgs:
+                        if len(args) < minArgs:
+                            bad("too few arguments to {}")
+                    for arg in args:
+                        if not variadic(arg):
+                            bad()
+                    return fn(*args)
 
-        elif argument_tests:
-            def invoke(*args):
-                if len(args) != len(argument_tests):
-                    bad()
-                for t, arg in zip(argument_tests, args):
-                    if not t(arg):
+            elif argument_tests:
+                def invoke(*args):
+                    if len(args) != len(argument_tests):
                         bad()
-                return fn(*args)
+                    for t, arg in zip(argument_tests, args):
+                        if not t(arg):
+                            bad()
+                    return fn(*args)
 
+            else:
+                def invoke(*args):
+                    return fn(*args)
+
+            builtins[name] = invoke
+            return fn
+        return wrap
+
+
+    def is_number(v):
+        return isinstance(v, (int, float)) and not isinstance(v, bool)
+
+
+    def is_string(v):
+        return isinstance(v, string)
+
+
+    def is_string_or_array(v):
+        return isinstance(v, (string, list))
+
+
+    def anything(v):
+        return isinstance(v, (string, int, float, list, dict)) or v is None or callable(v)
+
+    # ---
+
+
+    builtin('min', variadic=is_number, minArgs=1)(min)
+    builtin('max', variadic=is_number, minArgs=1)(max)
+    builtin('sqrt', argument_tests=[is_number])(math.sqrt)
+    builtin('abs', argument_tests=[is_number])(abs)
+
+
+    @builtin('ceil', argument_tests=[is_number])
+    def ceil(v):
+        return int(math.ceil(v))
+
+
+    @builtin('floor', argument_tests=[is_number])
+    def floor(v):
+        return int(math.floor(v))
+
+
+    @builtin('lowercase', argument_tests=[is_string])
+    def lowercase(v):
+        return v.lower()
+
+
+    @builtin('uppercase', argument_tests=[is_string])
+    def lowercase(v):
+        return v.upper()
+
+
+    builtin('len', argument_tests=[is_string_or_array])(len)
+
+
+    @builtin('str', argument_tests=[anything])
+    def to_str(v):
+        if isinstance(v, bool):
+            return {True: 'true', False: 'false'}[v]
+        elif isinstance(v, list):
+            return ','.join(to_str(e) for e in v)
         else:
-            def invoke(*args):
-                return fn(*args)
-
-        builtins[name] = invoke
-        return fn
-    return wrap
+            return str(v)
 
 
-def is_number(v):
-    return isinstance(v, (int, float)) and not isinstance(v, bool)
+    @builtin('str', argument_tests=[anything])
+    def to_str(v):
+        if isinstance(v, bool):
+            return {True: 'true', False: 'false'}[v]
+        elif isinstance(v, list):
+            return ','.join(to_str(e) for e in v)
+        elif v is None:
+            return 'null'
+        else:
+            return str(v)
 
 
-def is_string(v):
-    return isinstance(v, string)
+    @builtin('fromNow', variadic=is_string, minArgs=1)
+    def fromNow_builtin(offset, reference=None):
+        return fromNow(offset, reference or context.get('now'))
 
+    @builtin('typeof', argument_tests=[anything])
+    def typeof(v):
+        if isinstance(v, bool):
+            return 'boolean'
+        elif isinstance(v, string):
+            return 'string'
+        elif isinstance(v, (int, float)):
+            return 'number'
+        elif isinstance(v, list):
+            return 'array'
+        elif isinstance(v, dict):
+            return 'object'
+        elif v is None:
+            return None
+        elif callable(v):
+            return 'function'
 
-def is_string_or_array(v):
-    return isinstance(v, (string, list))
-
-
-def anything(v):
-    return isinstance(v, (string, int, float, list, dict)) or v is None or callable(v)
-
-# ---
-
-
-builtin('min', variadic=is_number, minArgs=1)(min)
-builtin('max', variadic=is_number, minArgs=1)(max)
-builtin('sqrt', argument_tests=[is_number])(math.sqrt)
-builtin('abs', argument_tests=[is_number])(abs)
-
-
-@builtin('ceil', argument_tests=[is_number])
-def ceil(v):
-    return int(math.ceil(v))
-
-
-@builtin('floor', argument_tests=[is_number])
-def floor(v):
-    return int(math.floor(v))
-
-
-@builtin('lowercase', argument_tests=[is_string])
-def lowercase(v):
-    return v.lower()
-
-
-@builtin('uppercase', argument_tests=[is_string])
-def lowercase(v):
-    return v.upper()
-
-
-builtin('len', argument_tests=[is_string_or_array])(len)
-
-
-@builtin('str', argument_tests=[anything])
-def to_str(v):
-    if isinstance(v, bool):
-        return {True: 'true', False: 'false'}[v]
-    elif isinstance(v, list):
-        return ','.join(to_str(e) for e in v)
-    else:
-        return str(v)
-
-
-@builtin('str', argument_tests=[anything])
-def to_str(v):
-    if isinstance(v, bool):
-        return {True: 'true', False: 'false'}[v]
-    elif isinstance(v, list):
-        return ','.join(to_str(e) for e in v)
-    elif v is None:
-        return 'null'
-    else:
-        return str(v)
-
-
-@builtin('fromNow', variadic=is_string, minArgs=1)
-def fromNow_builtin(offset, reference=None):
-    return fromNow(offset, reference)
-
-@builtin('typeof', argument_tests=[anything])
-def typeof(v):
-    if isinstance(v, bool):
-        return 'boolean'
-    elif isinstance(v, string):
-        return 'string'
-    elif isinstance(v, (int, float)):
-        return 'number'
-    elif isinstance(v, list):
-        return 'array'
-    elif isinstance(v, dict):
-        return 'object'
-    elif v is None:
-        return None
-    elif callable(v):
-        return 'function'
+    return builtins

--- a/jsone/builtins.py
+++ b/jsone/builtins.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 import math
-from .shared import string, fromNow, JSONTemplateError
+from .shared import string, to_str, fromNow, JSONTemplateError
 
 
 class BuiltinError(JSONTemplateError):
@@ -86,28 +86,7 @@ def build(context):
 
 
     builtin('len', argument_tests=[is_string_or_array])(len)
-
-
-    @builtin('str', argument_tests=[anything])
-    def to_str(v):
-        if isinstance(v, bool):
-            return {True: 'true', False: 'false'}[v]
-        elif isinstance(v, list):
-            return ','.join(to_str(e) for e in v)
-        else:
-            return str(v)
-
-
-    @builtin('str', argument_tests=[anything])
-    def to_str(v):
-        if isinstance(v, bool):
-            return {True: 'true', False: 'false'}[v]
-        elif isinstance(v, list):
-            return ','.join(to_str(e) for e in v)
-        elif v is None:
-            return 'null'
-        else:
-            return str(v)
+    builtin('str', argument_tests=[anything])(to_str)
 
 
     @builtin('fromNow', variadic=is_string, minArgs=1)

--- a/jsone/render.py
+++ b/jsone/render.py
@@ -2,9 +2,8 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 import re
 import json as json
-from .shared import JSONTemplateError, TemplateError, DeleteMarker, string
+from .shared import JSONTemplateError, TemplateError, DeleteMarker, string, to_str
 from . import shared
-from . import builtins
 from .interpreter import ExpressionEvaluator
 from .six import viewitems
 
@@ -40,7 +39,7 @@ def interpolate(string, context):
             if isinstance(parsed, (list, dict)):
                 raise TemplateError(
                     "interpolation of '{}' produced an array or object".format(string[:offset]))
-            result.append(builtins.build({})['str'](parsed))
+            result.append(to_str(parsed))
             string = string[offset + 1:]
         else:  # found `$${`
             result.append('${')

--- a/jsone/render.py
+++ b/jsone/render.py
@@ -40,7 +40,7 @@ def interpolate(string, context):
             if isinstance(parsed, (list, dict)):
                 raise TemplateError(
                     "interpolation of '{}' produced an array or object".format(string[:offset]))
-            result.append(builtins.to_str(parsed))
+            result.append(builtins.build({})['str'](parsed))
             string = string[offset + 1:]
         else:  # found `$${`
             result.append('${')
@@ -95,7 +95,7 @@ def flattenDeep(template, context):
 @operator('$fromNow')
 def fromNow(template, context):
     offset = renderValue(template['$fromNow'], context)
-    reference = renderValue(template['from'], context) if 'from' in template else None
+    reference = renderValue(template['from'], context) if 'from' in template else context.get('now')
 
     if not isinstance(offset, string):
         raise TemplateError("$fromNow expects a string")

--- a/jsone/shared.py
+++ b/jsone/shared.py
@@ -3,9 +3,6 @@ from __future__ import absolute_import, print_function, unicode_literals
 import re
 import datetime
 
-# this will be overridden in tests
-utcnow = datetime.datetime.utcnow
-
 
 class DeleteMarker:
     pass
@@ -88,10 +85,10 @@ def fromNow(offset, reference):
         seconds=seconds,
     )
 
-    if reference:
+    if isinstance(reference, str):
         reference = datetime.datetime.strptime(reference, '%Y-%m-%dT%H:%M:%S.%fZ')
-    else:
-        reference = utcnow()
+    elif reference is None:
+        reference = datetime.datetime.utcnow()
     return stringDate(reference + delta if future else reference - delta)
 
 

--- a/jsone/shared.py
+++ b/jsone/shared.py
@@ -95,6 +95,17 @@ def fromNow(offset, reference):
 datefmt_re = re.compile(r'(\.[0-9]{3})[0-9]*(\+00:00)?')
 
 
+def to_str(v):
+    if isinstance(v, bool):
+        return {True: 'true', False: 'false'}[v]
+    elif isinstance(v, list):
+        return ','.join(to_str(e) for e in v)
+    elif v is None:
+        return 'null'
+    else:
+        return str(v)
+
+
 def stringDate(date):
     # Convert to isoFormat
     string = date.isoformat()

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(name='json-e',
     test_suite='nose.collector',
     license='MPL2',
     tests_require=[
+        "freezegun",
         "hypothesis",
         "nose",
         "PyYAML",

--- a/src/builtins.js
+++ b/src/builtins.js
@@ -19,103 +19,105 @@ let types = {
 
 let builtinError = (builtin, expectation) => new BuiltinError(`${builtin} expects ${expectation}`);
 
-let builtins = {};
+module.exports = (context) => {
+  let builtins = {};
 
-let define = (name, context, {
-  argumentTests = [],
-  minArgs = false,
-  variadic = null,
-  invoke,
-}) => context[name] = (...args) => {
-  if (!variadic && args.length < argumentTests.length) {
-    throw builtinError(`builtin: ${name}`, `${args.toString()}, too few arguments`);
-  }
-
-  if (minArgs && args.length < minArgs) {
-    throw builtinError(`builtin: ${name}: expected at least ${minArgs} arguments`);
-  }
-
-  if (variadic) {
-    argumentTests = args.map(() => variadic);
-  }
-
-  args.forEach((arg, i) => {
-    if (!argumentTests[i].split('|').some(test => types[test](arg))) {
-      throw builtinError(`builtin: ${name}`, `argument ${i + 1} to be ${argumentTests[i]} found ${typeof arg}`);
+  let define = (name, context, {
+    argumentTests = [],
+    minArgs = false,
+    variadic = null,
+    invoke,
+  }) => context[name] = (...args) => {
+    if (!variadic && args.length < argumentTests.length) {
+      throw builtinError(`builtin: ${name}`, `${args.toString()}, too few arguments`);
     }
-  });
 
-  return invoke(...args);
-};
-
-// Math functions
-['max', 'min'].forEach(name => {
-  if (Math[name] == undefined) {
-    throw new Error(`${name} in Math undefined`);
-  }
-  define(name, builtins, {
-    minArgs: 1,
-    variadic: 'number',
-    invoke: (...args) => Math[name](...args),
-  });
-});
-
-['sqrt', 'ceil', 'floor', 'abs'].forEach(name => {
-  if (Math[name] == undefined) {
-    throw new Error(`${name} in Math undefined`);
-  }
-  define(name, builtins, {
-    argumentTests: ['number'],
-    invoke: num => Math[name](num),
-  });
-});
-
-// String manipulation
-define('lowercase', builtins, {
-  argumentTests: ['string'],
-  invoke: str => str.toLowerCase(),
-});
-
-define('uppercase', builtins, {
-  argumentTests: ['string'],
-  invoke: str => str.toUpperCase(),
-});
-
-define('str', builtins, {
-  argumentTests: ['string|number|boolean|array|null'],
-  invoke: obj => {
-    if (obj === null) {
-      return 'null';
+    if (minArgs && args.length < minArgs) {
+      throw builtinError(`builtin: ${name}: expected at least ${minArgs} arguments`);
     }
-    return obj.toString();
-  },
-});
 
-define('len', builtins, {
-  argumentTests: ['string|array'],
-  invoke: obj => obj.length,
-});
+    if (variadic) {
+      argumentTests = args.map(() => variadic);
+    }
 
-// Miscellaneous
-define('fromNow', builtins, {
-  variadic: 'string',
-  minArgs: 1,
-  invoke: (str, reference) => fromNow(str, reference),
-});
-
-define('typeof', builtins, {
-  argumentTests: ['string|number|boolean|array|object|null|function'],
-  invoke: x => {
-    for (type of ['string', 'number', 'boolean', 'array', 'object', 'function']) {
-      if (types[type](x)) {
-        return type;
+    args.forEach((arg, i) => {
+      if (!argumentTests[i].split('|').some(test => types[test](arg))) {
+        throw builtinError(`builtin: ${name}`, `argument ${i + 1} to be ${argumentTests[i]} found ${typeof arg}`);
       }
-    }
-    if (types['null'](x)) {
-      return null;
-    }
-    throw builtinError('builtin: typeof', `argument ${x} to be a valid json-e type. found ${typeof arg}`);
-  },
-});
+    });
 
-module.exports = builtins;
+    return invoke(...args);
+  };
+
+  // Math functions
+  ['max', 'min'].forEach(name => {
+    if (Math[name] == undefined) {
+      throw new Error(`${name} in Math undefined`);
+    }
+    define(name, builtins, {
+      minArgs: 1,
+      variadic: 'number',
+      invoke: (...args) => Math[name](...args),
+    });
+  });
+
+  ['sqrt', 'ceil', 'floor', 'abs'].forEach(name => {
+    if (Math[name] == undefined) {
+      throw new Error(`${name} in Math undefined`);
+    }
+    define(name, builtins, {
+      argumentTests: ['number'],
+      invoke: num => Math[name](num),
+    });
+  });
+
+  // String manipulation
+  define('lowercase', builtins, {
+    argumentTests: ['string'],
+    invoke: str => str.toLowerCase(),
+  });
+
+  define('uppercase', builtins, {
+    argumentTests: ['string'],
+    invoke: str => str.toUpperCase(),
+  });
+
+  define('str', builtins, {
+    argumentTests: ['string|number|boolean|array|null'],
+    invoke: obj => {
+      if (obj === null) {
+        return 'null';
+      }
+      return obj.toString();
+    },
+  });
+
+  define('len', builtins, {
+    argumentTests: ['string|array'],
+    invoke: obj => obj.length,
+  });
+
+  // Miscellaneous
+  define('fromNow', builtins, {
+    variadic: 'string',
+    minArgs: 1,
+    invoke: (str, reference) => fromNow(str, reference || context.now),
+  });
+
+  define('typeof', builtins, {
+    argumentTests: ['string|number|boolean|array|object|null|function'],
+    invoke: x => {
+      for (type of ['string', 'number', 'boolean', 'array', 'object', 'function']) {
+        if (types[type](x)) {
+          return type;
+        }
+      }
+      if (types['null'](x)) {
+        return null;
+      }
+      throw builtinError('builtin: typeof', `argument ${x} to be a valid json-e type. found ${typeof arg}`);
+    },
+  });
+
+  return Object.assign({}, builtins, context);
+};

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ var {
   isArray, isObject, isFunction,
   isTruthy,
 } = require('./type-utils');
-var builtins = require('./builtins');
+var addBuiltins = require('./builtins');
 var {JSONTemplateError, TemplateError} = require('./error');
 
 let flattenDeep = (a) => {
@@ -76,7 +76,7 @@ operators.$flattenDeep = (template, context) => {
 
 operators.$fromNow = (template, context) => {
   let value = render(template['$fromNow'], context);
-  let reference;
+  let reference = context.now;
   if (template['from']) {
     reference = render(template['from'], context);
   }
@@ -283,7 +283,7 @@ module.exports = (template, context = {}) => {
   if (!test) {
     throw new TemplateError('top level keys of context must follow /[a-zA-Z_][a-zA-Z0-9_]*/');
   }
-  context = Object.assign({}, builtins, context);
+  context = addBuiltins(Object.assign({}, {now: new Date()}, context));
   let result = render(template, context);
   if (result === deleteMarker) {
     return null;

--- a/test/misc_test.js
+++ b/test/misc_test.js
@@ -7,4 +7,18 @@ suite('misc', function() {
 
     assume(jsone({$eval: 'my_builtin(3, 4)'}, {my_builtin})).eql(5);
   });
+
+  test('time doesn\'t change mid-evaluation (operator)', function() {
+    let template = [...Array(1000).keys()].map(() => ({$fromNow: ''}));
+    let result = new Set(jsone(template, {}));
+
+    assume(result.size).eql(1);
+  });
+
+  test('time doesn\'t change mid-evaluation (builtin)', function() {
+    let template = [...Array(1000).keys()].map(() => ({$eval: 'fromNow("")'}));
+    let result = new Set(jsone(template, {}));
+
+    assume(result.size).eql(1);
+  });
 });

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -9,3 +9,13 @@ def test_custom_builtin():
     def my_builtin(x, y):
         return math.sqrt(x ** 2 + y ** 2)
     eq_(render({'$eval': 'my_builtin(3, 4)'}, {'my_builtin': my_builtin}), 5)
+
+def test_same_time_within_evaluation_operator():
+    template = [{'$fromNow': ''} for _ in range(1000)]
+    result = render(template, {})
+    eq_(len(set(result)), 1)
+
+def test_same_time_within_evaluation_builtin():
+    template = [{'$eval': 'fromNow("")'} for _ in range(1000)]
+    result = render(template, {})
+    eq_(len(set(result)), 1)

--- a/test/test_specification.py
+++ b/test/test_specification.py
@@ -1,20 +1,10 @@
-import dateutil.parser
 import jsone
 import os
 import unittest
 import yaml
 import jsone.shared
+from freezegun import freeze_time
 from nose.tools import eq_
-
-TEST_DATE = dateutil.parser.parse('2017-01-19T16:27:20.974Z')
-
-def setup_module():
-    global old_utcnow
-    old_utcnow = jsone.shared.utcnow
-    jsone.shared.utcnow = lambda: TEST_DATE
-
-def teardown_module():
-    jsone.shared.utcnow = old_utcnow
 
 def test():
     def spec_test(name, spec):
@@ -40,11 +30,12 @@ def test():
         return test
 
     with open(os.path.join(os.path.dirname(__file__), '../specification.yml')) as f:
-        for spec in yaml.load_all(f):
-            if 'section' in spec:
-                section = spec['section']
-                continue
+        with freeze_time('2017-01-19T16:27:20.974Z'):
+            for spec in yaml.load_all(f):
+                if 'section' in spec:
+                    section = spec['section']
+                    continue
 
-            name = '{}: {}'.format(section, spec['title'])
-            t = spec_test(name, spec)
-            yield (t, name)
+                name = '{}: {}'.format(section, spec['title'])
+                t = spec_test(name, spec)
+                yield (t, name)


### PR DESCRIPTION
This is the work we talked about in irc yesterday. Without this change, `fromNow` in different parts of a template can evaluate to different times when given the same input.

I'm not convinced that the way I've messed with `builtins` is best in both js and python. It seemed to be the most straightforward way to make this work though. Really happy to get suggestions there.