### PR TITLE
include package.json in python sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include jsone *.py
+include package.json
 recursive-exclude test *


### PR DESCRIPTION
I tried installing `json-e==2.3.0` from pypi, and got

```
(swenv) akimoz: /src/tc/scriptworker (cotv2*) (cotv2) [11:46:45]
10644$ pip install json-e
Collecting json-e
  Using cached json-e-2.3.0.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File
"/private/var/folders/y5/h9c4hgd54rv6ng12ynw3ydw00000gn/T/pip-build-qqeishr9/json-e/setup.py",
line 6, in <module>
        with open(package_json) as f:
    FileNotFoundError: [Errno 2] No such file or directory:
'/private/var/folders/y5/h9c4hgd54rv6ng12ynw3ydw00000gn/T/pip-build-qqeishr9/json-e/package.json'
```

Adding `package.json` to `MANIFEST.in` appears to fix the problem:
after running `python setup.py sdist`, the following works:

```
(swenv) akimoz: /src/tc/json-e (fix-package-json*) (fix-package-json)
[11:52:11]
10648$ pip install dist/json-e-2.3.0.tar.gz
Processing ./dist/json-e-2.3.0.tar.gz
Installing collected packages: json-e
  Running setup.py install for json-e ... done
Successfully installed json-e-2.3.0
```