### PR TITLE
`now` constant appears to be a Date, not a string #181

### DIFF
--- a/jsone/__init__.py
+++ b/jsone/__init__.py
@@ -1,9 +1,8 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
-import datetime
 import re
 from .render import renderValue
-from .shared import JSONTemplateError, DeleteMarker, TemplateError
+from .shared import JSONTemplateError, DeleteMarker, TemplateError, fromNow
 from . import builtins
 
 _context_re = re.compile(r'[a-zA-Z_][a-zA-Z0-9_]*$')
@@ -12,7 +11,7 @@ def render(template, context):
     if not all(_context_re.match(c) for c in context):
         raise TemplateError('top level keys of context must follow '
                                 '/[a-zA-Z_][a-zA-Z0-9_]*/')
-    full_context = {'now': datetime.datetime.utcnow()}
+    full_context = {'now': fromNow('0 seconds', None)}
     full_context.update(builtins.build(full_context))
     full_context.update(context)
     rv = renderValue(template, full_context)

--- a/jsone/shared.py
+++ b/jsone/shared.py
@@ -85,7 +85,7 @@ def fromNow(offset, reference):
         seconds=seconds,
     )
 
-    if isinstance(reference, str):
+    if isinstance(reference, string):
         reference = datetime.datetime.strptime(reference, '%Y-%m-%dT%H:%M:%S.%fZ')
     elif reference is None:
         reference = datetime.datetime.utcnow()

--- a/src/index.js
+++ b/src/index.js
@@ -323,7 +323,7 @@ module.exports = (template, context = {}) => {
   if (!test) {
     throw new TemplateError('top level keys of context must follow /[a-zA-Z_][a-zA-Z0-9_]*/');
   }
-  context = addBuiltins(Object.assign({}, {now: new Date()}, context));
+  context = addBuiltins(Object.assign({}, {now: fromNow('0 seconds')}, context));
   let result = render(template, context);
   if (result === deleteMarker) {
     return null;

--- a/test/misc_test.js
+++ b/test/misc_test.js
@@ -23,6 +23,6 @@ suite('misc', function() {
   });
 
   test('now builtin returns a string', function() {
-    assume(typeof jsone({$eval: 'now'}, {})).eql(typeof "string");
+    assume(typeof jsone({$eval: 'now'}, {})).eql(typeof 'string');
   });
 });

--- a/test/misc_test.js
+++ b/test/misc_test.js
@@ -21,4 +21,8 @@ suite('misc', function() {
 
     assume(result.size).eql(1);
   });
+
+  test('now builtin returns a string', function() {
+    assume(typeof jsone({$eval: 'now'}, {})).eql(typeof "string");
+  });
 });

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -19,3 +19,6 @@ def test_same_time_within_evaluation_builtin():
     template = [{'$eval': 'fromNow("")'} for _ in range(1000)]
     result = render(template, {})
     eq_(len(set(result)), 1)
+
+def test_now_builtin():
+    eq_(isinstance(render({'$eval': 'now'}, {}), str), True)

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 import math
 from nose.tools import eq_
+from jsone.shared import string 
 from jsone import render, JSONTemplateError
 
 
@@ -21,4 +22,4 @@ def test_same_time_within_evaluation_builtin():
     eq_(len(set(result)), 1)
 
 def test_now_builtin():
-    eq_(isinstance(render({'$eval': 'now'}, {}), str), True)
+    eq_(isinstance(render({'$eval': 'now'}, {}), string), True)


### PR DESCRIPTION
Fixing #181. 

After looking at the code, I could see that now was implemented by simply creating a new DateTime object. Instead, I call the $fromNow method already implemented to not create redundant code. I added two simple tests to ensure it worked properly. Feedback is welcomed.  

