### PR TITLE
Prohibit undefined properties for $merge

### DIFF
--- a/jsone/render.py
+++ b/jsone/render.py
@@ -57,6 +57,14 @@ def interpolate(string, context):
 
     return ''.join(result)
 
+def checkUndefinedProperties(operator, template, allowed):
+    unknownKeys = ""
+    for key in sorted(template):
+        if key not in allowed and key != operator:
+            unknownKeys += " " + key
+    if unknownKeys:
+        raise TemplateError(operator + " has undefined properties:" + unknownKeys)
+
 
 @operator('$eval')
 def eval(template, context):
@@ -181,6 +189,7 @@ def map(template, context):
 
 @operator('$merge')
 def merge(template, context):
+    checkUndefinedProperties('$merge', template, [])
     value = renderValue(template['$merge'], context)
     if not isinstance(value, list) or not all(isinstance(e, dict) for e in value):
         raise TemplateError("$merge value must evaluate to an array of objects")

--- a/specification.yml
+++ b/specification.yml
@@ -775,6 +775,11 @@ title: $merge [null]
 template: {$merge: [null]}
 context: {}
 error: 'TemplateError: $merge value must evaluate to an array of objects'
+---
+title: merge with undefined properties
+template: {$merge: [{a: 1}, {b: 2, c: 3}, {d: 4}], foo: "bar", bing: "baz"}
+context: {}
+error: 'TemplateError: $merge has undefined properties: bing foo'
 ################################################################################
 ---
 section:  $mergeDeep

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,18 @@ var {
 var addBuiltins = require('./builtins');
 var {JSONTemplateError, TemplateError} = require('./error');
 
+function checkUndefinedProperties(operator, template, allowed) {
+  var unknownKeys = '';
+  for (var key of Object.keys(template).sort()) {
+    if (!allowed.includes(key) && key != operator) {
+      unknownKeys += ' ' + key;
+    }
+  }
+  if (unknownKeys) {
+    throw new TemplateError(operator + ' has undefined properties:' + unknownKeys);
+  }
+};
+
 let flattenDeep = (a) => {
   return Array.isArray(a) ? [].concat(...a.map(flattenDeep)) : a;
 };
@@ -157,6 +169,8 @@ operators.$map = (template, context) => {
 };
 
 operators.$merge = (template, context) => {
+  checkUndefinedProperties('$merge', template, []);
+
   let value = render(template['$merge'], context);
 
   if (!isArray(value) || value.some(o => !isObject(o))) {


### PR DESCRIPTION
See https://github.com/taskcluster/json-e/issues/176

@djmitche I have only disallowed undefined properties for `$merge` in this pull request as I was unsure of the implementation. If this is okay, I'll do it for the rest of the operators. 