### PR TITLE
Prohibit extra keys for operators

### DIFF
--- a/jsone/render.py
+++ b/jsone/render.py
@@ -73,6 +73,7 @@ def eval(template, context):
 
 @operator('$flatten')
 def flatten(template, context):
+    checkUndefinedProperties('$flatten', template, [])
     value = renderValue(template['$flatten'], context)
     if not isinstance(value, list):
         raise TemplateError('$flatten value must evaluate to an array')
@@ -89,6 +90,7 @@ def flatten(template, context):
 
 @operator('$flattenDeep')
 def flattenDeep(template, context):
+    checkUndefinedProperties('$flattenDeep', template, [])
     value = renderValue(template['$flattenDeep'], context)
     if not isinstance(value, list):
         raise TemplateError('$flattenDeep value must evaluate to an array')
@@ -106,6 +108,7 @@ def flattenDeep(template, context):
 
 @operator('$fromNow')
 def fromNow(template, context):
+    checkUndefinedProperties('$fromNow', template, ['from'])
     offset = renderValue(template['$fromNow'], context)
     reference = renderValue(template['from'], context) if 'from' in template else context.get('now')
 
@@ -116,6 +119,7 @@ def fromNow(template, context):
 
 @operator('$if')
 def ifConstruct(template, context):
+    checkUndefinedProperties('$if', template, ['then', 'else'])
     condition = evaluateExpression(template['$if'], context)
     try:
         if condition:
@@ -129,12 +133,14 @@ def ifConstruct(template, context):
 
 @operator('$json')
 def jsonConstruct(template, context):
+    checkUndefinedProperties('$json', template, [])
     value = renderValue(template['$json'], context)
     return json.dumps(value, separators=(',', ':'))
 
 
 @operator('$let')
 def let(template, context):
+    checkUndefinedProperties('$let', template, ['in'])
     variables = renderValue(template['$let'], context)    
     
     if not isinstance(variables, dict):
@@ -201,6 +207,7 @@ def merge(template, context):
 
 @operator('$mergeDeep')
 def merge(template, context):
+    checkUndefinedProperties('$mergeDeep', template, [])
     value = renderValue(template['$mergeDeep'], context)
     if not isinstance(value, list) or not all(isinstance(e, dict) for e in value):
         raise TemplateError("$mergeDeep value must evaluate to an array of objects")
@@ -223,6 +230,7 @@ def merge(template, context):
 
 @operator('$reverse')
 def reverse(template, context):
+    checkUndefinedProperties('$reverse', template, [])
     value = renderValue(template['$reverse'], context)
     if not isinstance(value, list):
         raise TemplateError("$reverse value must evaluate to an array")

--- a/jsone/render.py
+++ b/jsone/render.py
@@ -60,13 +60,14 @@ def interpolate(string, context):
     return ''.join(result)
 
 
-def checkUndefinedProperties(operator, template, allowed):
+def checkUndefinedProperties(template, allowed):
     unknownKeys = []
     combined = "|".join(allowed) + "$"
     unknownKeys = [key for key in sorted(template)
-                   if key != operator and not re.match(combined, key)]
+                   if not re.match(combined, key)]
     if unknownKeys:
-        raise TemplateError(operator + " has undefined properties: " + " ".join(unknownKeys))
+        raise TemplateError(allowed[0].replace('\\', '') +
+                            " has undefined properties: " + " ".join(unknownKeys))
 
 
 @operator('$eval')
@@ -76,7 +77,7 @@ def eval(template, context):
 
 @operator('$flatten')
 def flatten(template, context):
-    checkUndefinedProperties('$flatten', template, [])
+    checkUndefinedProperties(template, ['\$flatten'])
     value = renderValue(template['$flatten'], context)
     if not isinstance(value, list):
         raise TemplateError('$flatten value must evaluate to an array')
@@ -93,7 +94,7 @@ def flatten(template, context):
 
 @operator('$flattenDeep')
 def flattenDeep(template, context):
-    checkUndefinedProperties('$flattenDeep', template, [])
+    checkUndefinedProperties(template, ['\$flattenDeep'])
     value = renderValue(template['$flattenDeep'], context)
     if not isinstance(value, list):
         raise TemplateError('$flattenDeep value must evaluate to an array')
@@ -111,7 +112,7 @@ def flattenDeep(template, context):
 
 @operator('$fromNow')
 def fromNow(template, context):
-    checkUndefinedProperties('$fromNow', template, ['from'])
+    checkUndefinedProperties(template, ['\$fromNow', 'from'])
     offset = renderValue(template['$fromNow'], context)
     reference = renderValue(
         template['from'], context) if 'from' in template else context.get('now')
@@ -123,7 +124,7 @@ def fromNow(template, context):
 
 @operator('$if')
 def ifConstruct(template, context):
-    checkUndefinedProperties('$if', template, ['then', 'else'])
+    checkUndefinedProperties(template, ['\$if', 'then', 'else'])
     condition = evaluateExpression(template['$if'], context)
     try:
         if condition:
@@ -137,14 +138,14 @@ def ifConstruct(template, context):
 
 @operator('$json')
 def jsonConstruct(template, context):
-    checkUndefinedProperties('$json', template, [])
+    checkUndefinedProperties(template, ['\$json'])
     value = renderValue(template['$json'], context)
     return json.dumps(value, separators=(',', ':'))
 
 
 @operator('$let')
 def let(template, context):
-    checkUndefinedProperties('$let', template, ['in'])
+    checkUndefinedProperties(template, ['\$let', 'in'])
     variables = renderValue(template['$let'], context)
     if not isinstance(variables, dict):
         raise TemplateError("$let value must evaluate to an object")
@@ -164,7 +165,7 @@ def let(template, context):
 @operator('$map')
 def map(template, context):
     EACH_RE = 'each\([a-zA-Z_][a-zA-Z0-9_]*\)'
-    checkUndefinedProperties('$map', template, [EACH_RE])
+    checkUndefinedProperties(template, ['\$map', EACH_RE])
     value = renderValue(template['$map'], context)
     if not isinstance(value, list) and not isinstance(value, dict):
         raise TemplateError("$map value must evaluate to an array or object")
@@ -201,7 +202,7 @@ def map(template, context):
 
 @operator('$merge')
 def merge(template, context):
-    checkUndefinedProperties('$merge', template, [])
+    checkUndefinedProperties(template, ['\$merge'])
     value = renderValue(template['$merge'], context)
     if not isinstance(value, list) or not all(isinstance(e, dict) for e in value):
         raise TemplateError(
@@ -214,7 +215,7 @@ def merge(template, context):
 
 @operator('$mergeDeep')
 def merge(template, context):
-    checkUndefinedProperties('$mergeDeep', template, [])
+    checkUndefinedProperties(template, ['\$mergeDeep'])
     value = renderValue(template['$mergeDeep'], context)
     if not isinstance(value, list) or not all(isinstance(e, dict) for e in value):
         raise TemplateError(
@@ -239,7 +240,7 @@ def merge(template, context):
 
 @operator('$reverse')
 def reverse(template, context):
-    checkUndefinedProperties('$reverse', template, [])
+    checkUndefinedProperties(template, ['\$reverse'])
     value = renderValue(template['$reverse'], context)
     if not isinstance(value, list):
         raise TemplateError("$reverse value must evaluate to an array")
@@ -249,7 +250,7 @@ def reverse(template, context):
 @operator('$sort')
 def sort(template, context):
     BY_RE = 'by\([a-zA-Z_][a-zA-Z0-9_]*\)'
-    checkUndefinedProperties('$sort', template, [BY_RE])
+    checkUndefinedProperties(template, ['\$sort', BY_RE])
     value = renderValue(template['$sort'], context)
     if not isinstance(value, list):
         raise TemplateError("$sort value must evaluate to an array")

--- a/specification.yml
+++ b/specification.yml
@@ -262,6 +262,11 @@ title:    $if->then evaluating to nothing at the top level is null
 context:  {cond: false}
 template: {$if: 'cond', then: "t"}
 result:   null
+---
+title:    $if-then-else with undefined properties
+context:  {cond: true}
+template: {$if: 'cond', then: 1, foo: 'bar', else: 2, bing: 'baz'}
+error: 'TemplateError: $if has undefined properties: bing foo'
 ################################################################################
 ---
 section:  escape operators
@@ -378,6 +383,11 @@ title:    flatten mixed levels
 context:  {}
 template: {$flatten: [[1, [2, 3]], [4], 5]}
 result:   [1, [2, 3], 4, 5]
+---
+title:    flatten with undefined properties
+context:  {}
+template: {$flatten: {$eval: '[[1], [2, 3]]'}, foo: 'bar'}
+error: 'TemplateError: $flatten has undefined properties: foo'
 ################################################################################
 ---
 section:  $flattenDeep
@@ -431,6 +441,11 @@ title:    flattenDeep mixed levels
 context:  {}
 template: {$flattenDeep: [[1, [2, 3]], [4], 5]}
 result:   [1, 2, 3, 4, 5]
+---
+title:    flattenDeep with undefined properties
+context:  {}
+template: {$flattenDeep: [[1, [2, 3]], [4], 5], foo: 'bar'}
+error: 'TemplateError: $flattenDeep has undefined properties: foo'
 ################################################################################
 ---
 section:  fromNow
@@ -544,6 +559,11 @@ title:    fromNow with reference
 context:  {now: '2019-01-01T01:00:00.123Z'}
 template: {$fromNow: '3 mo', from: {$eval: now}}
 result:   '2019-04-01T01:00:00.123Z'
+---
+title:    fromNow with undefined properties
+context:  {now: '2019-01-01T01:00:00.123Z'}
+template: {$fromNow: '3 mo', from: {$eval: now}, foo: 'bar'}
+error: 'TemplateError: $fromNow has undefined properties: foo'
 ################################################################################
 ---
 section:  $json
@@ -562,6 +582,11 @@ title:    $eval inside array
 context:  {a: 1, b: 2}
 template: {$json: [2, 5, {$eval: 'a + b + 7'}]}
 result:   '[2,5,10]'
+---
+title:    $json with undefined properties
+context:  {}
+template: {$json: [1,2,true,{},[]], foo: 'bar'}
+error: 'TemplateError: $json has undefined properties: foo'
 ################################################################################
 ---
 section: accessing nested objects => context
@@ -619,10 +644,10 @@ template: {$let: {x: 20, y: 10}, in: {$let: {x: 30}, in: {$eval: "x + y + z"}}}
 context:  {x: 1, y: 2, z: 3}
 result:   43
 ---
-title:    let without in
+title:    let with undefined properties
 template: {$let: {x: 1, y: 2}, a: {$eval: "x + y"}}
 context:  {}
-error:    'TemplateError: $let operator requires an `in` clause'
+error:    'TemplateError: $let has undefined properties: a'
 ---
 title:    let array
 template: {$let: [1, 2], in: {$eval: "1 + 2"}}
@@ -843,6 +868,11 @@ title: $mergeDeep [null]
 template: {$mergeDeep: [null]}
 context: {}
 error: 'TemplateError: $mergeDeep value must evaluate to an array of objects'
+---
+title: mergeDeep with undefined properties
+template: {$mergeDeep: [{a: {x: 1, y: 2}}, {a: {y: 3, z: 4}}], foo: "bar", bing: "baz"}
+context: {}
+error: 'TemplateError: $mergeDeep has undefined properties: bing foo'
 ################################################################################
 ---
 section:  $sort
@@ -1013,6 +1043,11 @@ title:    simple reverse + $sort # with this we can sort in reverse order
 context:  {}
 template: {$reverse: {$sort: [3, 4, 1, 2]}}
 result:   [4, 3, 2, 1]
+---
+title: reverse with undefined properties
+template: {$reverse: [3, 4, 1, 2], foo: "bar", bing: "baz"}
+context: {}
+error: 'TemplateError: $reverse has undefined properties: bing foo'
 ################################################################################
 ---
 section: $eval

--- a/specification.yml
+++ b/specification.yml
@@ -767,6 +767,14 @@ template:
   $map: null
   each(y): {$eval: 'y.k'}
 error: 'TemplateError: $map value must evaluate to an array or object'
+---
+title:    map with undefined properties
+context:  {a: 1}
+template:
+  $map: [2, 4, 6]
+  each(x): {$eval: 'x + a'}
+  foo: 'bar'
+error: 'TemplateError: $map has undefined properties: foo'
 ################################################################################
 ---
 section:  $merge
@@ -995,6 +1003,14 @@ context:  {}
 template:
   $sort:  null
 error: true  # $sort must be given an array
+---
+title:    sort with undefined properties
+context:  {}
+template:
+  $sort: [{s: 'android'}, {s: 'add'}, {s: 'adderall'}]
+  by(x): 'x.s'
+  foo:   'bar'
+error: 'TemplateError: $sort has undefined properties: foo'
 ################################################################################
 ---
 section:  $reverse

--- a/src/index.js
+++ b/src/index.js
@@ -11,8 +11,9 @@ var {JSONTemplateError, TemplateError} = require('./error');
 
 function checkUndefinedProperties(operator, template, allowed) {
   var unknownKeys = '';
+  var combined = new RegExp(allowed.join('|') + '$');
   for (var key of Object.keys(template).sort()) {
-    if (!allowed.includes(key) && key != operator) {
+    if (key != operator && (!combined.test(key) || combined.test('$'))) {
       unknownKeys += ' ' + key;
     }
   }
@@ -146,6 +147,8 @@ operators.$let = (template, context) => {
 };
 
 operators.$map = (template, context) => {
+  EACH_RE = 'each\\(([a-zA-Z_][a-zA-Z0-9_]*)\\)';
+  checkUndefinedProperties('$map', template, [EACH_RE]);
   let value = render(template['$map'], context);
   if (!isArray(value) && !isObject(value)) {
     throw new TemplateError('$map value must evaluate to an array or object');
@@ -243,6 +246,8 @@ operators.$reverse = (template, context) => {
 };
 
 operators.$sort = (template, context) => {
+  BY_RE = 'by\\(([a-zA-Z_][a-zA-Z0-9_]*)\\)';
+  checkUndefinedProperties('$sort', template, [BY_RE]);
   let value = render(template['$sort'], context);
   if (!isArray(value)) {
     throw new TemplateError('$sort requires array as value');

--- a/src/index.js
+++ b/src/index.js
@@ -9,16 +9,16 @@ var {
 var addBuiltins = require('./builtins');
 var {JSONTemplateError, TemplateError} = require('./error');
 
-function checkUndefinedProperties(operator, template, allowed) {
+function checkUndefinedProperties(template, allowed) {
   var unknownKeys = '';
   var combined = new RegExp(allowed.join('|') + '$');
   for (var key of Object.keys(template).sort()) {
-    if (key != operator && (!combined.test(key) || combined.test('$'))) {
+    if (!combined.test(key)) {
       unknownKeys += ' ' + key;
     }
   }
   if (unknownKeys) {
-    throw new TemplateError(operator + ' has undefined properties:' + unknownKeys);
+    throw new TemplateError(allowed[0].replace('\\', '') + ' has undefined properties:' + unknownKeys);
   }
 };
 
@@ -68,7 +68,7 @@ operators.$eval = (template, context) => {
 };
 
 operators.$flatten = (template, context) => {
-  checkUndefinedProperties('$flatten', template, []);
+  checkUndefinedProperties(template, ['\\$flatten']);
 
   let value = render(template['$flatten'], context);
 
@@ -80,7 +80,7 @@ operators.$flatten = (template, context) => {
 };
 
 operators.$flattenDeep = (template, context) => {
-  checkUndefinedProperties('$flattenDeep', template, []);
+  checkUndefinedProperties(template, ['\\$flattenDeep']);
 
   let value = render(template['$flattenDeep'], context);
 
@@ -92,7 +92,7 @@ operators.$flattenDeep = (template, context) => {
 };
 
 operators.$fromNow = (template, context) => {
-  checkUndefinedProperties('$fromNow', template, ['from']);
+  checkUndefinedProperties(template, ['\\$fromNow', 'from']);
 
   let value = render(template['$fromNow'], context);
   let reference = context.now;
@@ -106,7 +106,7 @@ operators.$fromNow = (template, context) => {
 };
 
 operators.$if = (template, context) => {
-  checkUndefinedProperties('$if', template, ['then', 'else']);
+  checkUndefinedProperties(template, ['\\$if', 'then', 'else']);
 
   if (!isString(template['$if'])) {
     throw new TemplateError('$if can evaluate string expressions only');
@@ -118,13 +118,13 @@ operators.$if = (template, context) => {
 };
 
 operators.$json = (template, context) => {
-  checkUndefinedProperties('$json', template, []);
+  checkUndefinedProperties(template, ['\\$json']);
 
   return JSON.stringify(render(template['$json'], context));
 };
 
 operators.$let = (template, context) => {
-  checkUndefinedProperties('$let', template, ['in']);
+  checkUndefinedProperties(template, ['\\$let', 'in']);
 
   let variables = render(template['$let'], context);
 
@@ -148,7 +148,7 @@ operators.$let = (template, context) => {
 
 operators.$map = (template, context) => {
   EACH_RE = 'each\\(([a-zA-Z_][a-zA-Z0-9_]*)\\)';
-  checkUndefinedProperties('$map', template, [EACH_RE]);
+  checkUndefinedProperties(template, ['\\$map', EACH_RE]);
   let value = render(template['$map'], context);
   if (!isArray(value) && !isObject(value)) {
     throw new TemplateError('$map value must evaluate to an array or object');
@@ -184,7 +184,7 @@ operators.$map = (template, context) => {
 };
 
 operators.$merge = (template, context) => {
-  checkUndefinedProperties('$merge', template, []);
+  checkUndefinedProperties(template, ['\\$merge']);
 
   let value = render(template['$merge'], context);
 
@@ -196,7 +196,7 @@ operators.$merge = (template, context) => {
 };
 
 operators.$mergeDeep = (template, context) => {
-  checkUndefinedProperties('$mergeDeep', template, []);
+  checkUndefinedProperties(template, ['\\$mergeDeep']);
 
   let value = render(template['$mergeDeep'], context);
 
@@ -231,7 +231,7 @@ operators.$mergeDeep = (template, context) => {
 };
 
 operators.$reverse = (template, context) => {
-  checkUndefinedProperties('$reverse', template, []);
+  checkUndefinedProperties(template, ['\\$reverse']);
 
   let value = render(template['$reverse'], context);
 
@@ -247,7 +247,7 @@ operators.$reverse = (template, context) => {
 
 operators.$sort = (template, context) => {
   BY_RE = 'by\\(([a-zA-Z_][a-zA-Z0-9_]*)\\)';
-  checkUndefinedProperties('$sort', template, [BY_RE]);
+  checkUndefinedProperties(template, ['\\$sort', BY_RE]);
   let value = render(template['$sort'], context);
   if (!isArray(value)) {
     throw new TemplateError('$sort requires array as value');

--- a/src/index.js
+++ b/src/index.js
@@ -67,6 +67,8 @@ operators.$eval = (template, context) => {
 };
 
 operators.$flatten = (template, context) => {
+  checkUndefinedProperties('$flatten', template, []);
+
   let value = render(template['$flatten'], context);
 
   if (!isArray(value)) {
@@ -77,6 +79,8 @@ operators.$flatten = (template, context) => {
 };
 
 operators.$flattenDeep = (template, context) => {
+  checkUndefinedProperties('$flattenDeep', template, []);
+
   let value = render(template['$flattenDeep'], context);
 
   if (!isArray(value)) {
@@ -87,6 +91,8 @@ operators.$flattenDeep = (template, context) => {
 };
 
 operators.$fromNow = (template, context) => {
+  checkUndefinedProperties('$fromNow', template, ['from']);
+
   let value = render(template['$fromNow'], context);
   let reference = context.now;
   if (template['from']) {
@@ -99,6 +105,8 @@ operators.$fromNow = (template, context) => {
 };
 
 operators.$if = (template, context) => {
+  checkUndefinedProperties('$if', template, ['then', 'else']);
+
   if (!isString(template['$if'])) {
     throw new TemplateError('$if can evaluate string expressions only');
   }
@@ -109,10 +117,14 @@ operators.$if = (template, context) => {
 };
 
 operators.$json = (template, context) => {
+  checkUndefinedProperties('$json', template, []);
+
   return JSON.stringify(render(template['$json'], context));
 };
 
 operators.$let = (template, context) => {
+  checkUndefinedProperties('$let', template, ['in']);
+
   let variables = render(template['$let'], context);
 
   var context_copy = Object.assign(context, variables);
@@ -181,6 +193,8 @@ operators.$merge = (template, context) => {
 };
 
 operators.$mergeDeep = (template, context) => {
+  checkUndefinedProperties('$mergeDeep', template, []);
+
   let value = render(template['$mergeDeep'], context);
 
   if (!isArray(value) || value.some(o => !isObject(o))) {
@@ -214,6 +228,8 @@ operators.$mergeDeep = (template, context) => {
 };
 
 operators.$reverse = (template, context) => {
+  checkUndefinedProperties('$reverse', template, []);
+
   let value = render(template['$reverse'], context);
 
   if (!isArray(value) && !isArray(template['$reverse'])) {


### PR DESCRIPTION
Operators included
``` 
$mergeDeep 
$flatten 
$flattenDeep 
$let 
$if 
$reverse 
$json 
$fromNow
```
@djmitche I am unsure of the representation for `$map` which takes `each(var)` and `$sort` which takes `by(var)`. Should I use regex to represent `var` while passing allowed keys? 

Fixes https://github.com/taskcluster/json-e/issues/176