### PR TITLE
Operators || and && evaluates right too soon

### DIFF
--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -292,10 +292,9 @@ infixRules['>='] = infixRules['<'] =  infixRules['>']
 
 infixRules['||'] = infixRules['&&'] = (left, token, ctx) => {
   let operator = token.kind;
-  let right = ctx.parse(operator);
   switch (operator) {
-    case '||':  return isTruthy(left) || isTruthy(right);
-    case '&&':  return isTruthy(left) && isTruthy(right);
+    case '||':  return isTruthy(left) || isTruthy(ctx.parse(operator));
+    case '&&':  return isTruthy(left) && isTruthy(ctx.parse(operator));
     default:    throw new Error('no rule for boolean operator: ' + operator);
   }
 };


### PR DESCRIPTION
Test cases for this is needed, we can check by adding an interpreting error on the right hand side..

THIS PR is really a bug report, with a partial fix, test-cases are needed. Please don't merge without tests...