### PR TITLE
Change how we flatten arrays to appease babel

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -76,7 +76,7 @@ operators.$flatten = (template, context) => {
     throw new TemplateError('$flatten value must evaluate to an array');
   }
 
-  return [].concat(...value);
+  return value.reduce((a, b) => a.concat(b), []);
 };
 
 operators.$flattenDeep = (template, context) => {


### PR DESCRIPTION
Previous to this change, it was transpiling to `[...value]`
which doesn't really do anything. It is a bit hard for us to
upgrade our dependencies (or at least it fought me a lot today)
so I think maybe we should just do it this way and move on with our
lives.

I'm happy to take or leave this. Somebody can go do the hard work on upgrading neutrino later if we want.