### PR TITLE
Precedence of `in` relative to `||`

### DIFF
--- a/jsone/interpreter.py
+++ b/jsone/interpreter.py
@@ -44,9 +44,9 @@ class ExpressionEvaluator(PrattParser):
         'null', 'number', 'identifier', 'string',
     ]
     precedence = [
-        ['in'],
         ['||'],
         ['&&'],
+        ['in'],
         ['==', '!='],
         ['>=', '<=', '<', '>'],
         ['+', '-'],

--- a/specification.yml
+++ b/specification.yml
@@ -4044,18 +4044,18 @@ template: {$eval: '[44, 45] in ["string", 46, [44]]'}
 result: false
 ---
 title: 'precedence of in over ||'
-context: {a: 'a' , b: ['a','b']}
+context: {a: 'a', b: 'ab'}
 template: {$eval: "a in b || true"}
 result: true    
 ---
-title: "precedence of in over &&"
-context: {a: 'a' , b: ['b','c']}
+title: 'precedence of in over &&'
+context: {a: 'a', b: 'bc'}
 template: {$eval: "a in b && true"}
 result: false
 ---
 title: 'compare precedence of in and =='
-context = {a: 'a' , b: ['a','b'] , x: 5 , y: 7 }
-template = {$eval: "a in b || x==y"}
+context: {a: 'a', b: 'ab', x: 5, y: 7 }
+template: {$eval: "a in b || x==y"}
 result: true
 ################################################################################
 ---
@@ -4750,7 +4750,7 @@ result: {a: 1, b: 1}
 title: 'parse object (12)'
 context: {key: 1}
 template: {$eval: '{a: key, b: key + 1'}
-error: truez
+error: true
 ################################################################################
 ---
 section: expression language - errors

--- a/specification.yml
+++ b/specification.yml
@@ -4042,6 +4042,21 @@ title: 'deep equality, Array on left side, not found'
 context: {}
 template: {$eval: '[44, 45] in ["string", 46, [44]]'}
 result: false
+---
+title: 'precedence of in over ||'
+context: {a: 'a' , b: ['a','b']}
+template: {$eval: "a in b || true"}
+result: true    
+---
+title: "precedence of in over &&"
+context: {a: 'a' , b: ['b','c']}
+template: {$eval: "a in b && true"}
+result: false
+---
+title: 'compare precedence of in and =='
+context = {a: 'a' , b: ['a','b'] , x: 5 , y: 7 }
+template = {$eval: "a in b || x==y"}
+result: true
 ################################################################################
 ---
 section: expression language - comparisons
@@ -4735,7 +4750,7 @@ result: {a: 1, b: 1}
 title: 'parse object (12)'
 context: {key: 1}
 template: {$eval: '{a: key, b: key + 1'}
-error: true
+error: truez
 ################################################################################
 ---
 section: expression language - errors

--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -339,9 +339,9 @@ module.exports = new PrattParser({
     'identifier', 'string',
   ],
   precedence: [
-    ['in'],
     ['||'],
     ['&&'],
+    ['in'],
     ['==', '!='],
     ['>=', '<=', '<', '>'],
     ['+', '-'],


### PR DESCRIPTION
Fixes #201 
Added the three test cases to `specification.yml`  and changed to precedence of `in` . It now looks like this 
```
 precedence: [
    ['||'],
    ['&&'],
    ['in'],
    ['==', '!='],
    ['>=', '<=', '<', '>'],
    ... 
 ]
```
All tests pass successfully!