### PR TITLE
bug 1328719 - sort $json output.

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,9 +183,10 @@ calculated value to eval is not allowed.  For example, `{$eval: {$eval:
 
 ### `$json`
 
-The `$json` operator formats the given value as JSON. It does not evaluate the
-value (use `$eval` for that). While this can be useful in some cases, it is an
-unusual case to include a JSON string in a larger data structure.
+The `$json` operator formats the given value as JSON with sorted keys. It does
+not evaluate the value (use `$eval` for that). While this can be useful in some
+cases, it is an unusual case to include a JSON string in a larger data
+structure.
 
 ```yaml
 template: {$json: [a, b, {$eval: 'a+b'}, 4]}

--- a/jsone/render.py
+++ b/jsone/render.py
@@ -143,7 +143,7 @@ def ifConstruct(template, context):
 def jsonConstruct(template, context):
     checkUndefinedProperties(template, ['\$json'])
     value = renderValue(template['$json'], context)
-    return json.dumps(value, separators=(',', ':'))
+    return json.dumps(value, separators=(',', ':'), sort_keys=True)
 
 
 @operator('$let')

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
   },
   "author": "",
   "license": "MPL-2.0",
-  "dependencies": {},
+  "dependencies": {
+    "json-stable-stringify": "^1.0.1"
+  },
   "devDependencies": {
     "assume": "^1.5.2",
     "browserify": "^14.5.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "assume": "^1.5.2",
     "browserify": "^14.5.0",
     "eslint-config-taskcluster": "^3.0.0",
+    "json-stable-stringify": "^1.0.1",
     "mocha": "^4.0.1",
     "source-map-support": "^0.5.0",
     "timekeeper": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "assume": "^1.5.2",
     "browserify": "^14.5.0",
     "eslint-config-taskcluster": "^3.0.0",
-    "json-stable-stringify": "^1.0.1",
     "mocha": "^4.0.1",
     "source-map-support": "^0.5.0",
     "timekeeper": "^2.0.0"

--- a/specification.yml
+++ b/specification.yml
@@ -44,8 +44,8 @@ result:   '[1,2,true,{},[]]'
 ---
 title:    $json alphabetical
 context:  {}
-template: {$json: {'q':1,'a':'Z','r':'f3s'}}
-result:   '{"a":"Z","q":1,"r":"f3s"}'
+template: {$json: {'Z':null,'q':1,'a':{'c':45,'b':['9',8,{}]},'r':true}}
+result:   '{"Z":null,"a":{"b":["9",8,{}],"c":45},"q":1,"r":true}'
 ---
 title:    string interpolation
 context:  {key: 'world', num: 1}

--- a/specification.yml
+++ b/specification.yml
@@ -42,6 +42,11 @@ context:  {}
 template: {$json: [1,2,true,{},[]]}
 result:   '[1,2,true,{},[]]'
 ---
+title:    $json alphabetical
+context:  {}
+template: {$json: {'q':1,'a':'Z','r':'f3s'}}
+result:   '{"a":"Z","q":1,"r":"f3s"}'
+---
 title:    string interpolation
 context:  {key: 'world', num: 1}
 template: {message: 'hello ${key}', 'k-${num}': true}

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 var interpreter = require('./interpreter');
 var fromNow = require('./from-now');
 var assert = require('assert');
+var stringify = require('json-stable-stringify');
 var {
   isString, isNumber, isBool,
   isArray, isObject, isFunction,
@@ -125,7 +126,7 @@ operators.$if = (template, context) => {
 operators.$json = (template, context) => {
   checkUndefinedProperties(template, ['\\$json']);
 
-  return JSON.stringify(render(template['$json'], context));
+  return stringify(render(template['$json'], context));
 };
 
 operators.$let = (template, context) => {


### PR DESCRIPTION
Since we need to be able to deterministically rebuild task definitions
via json-e, we need the output to be deterministic. This means sorting
$json.

I'm pretty confident in the python fix, but would like extra attention
on the js fix. Go `json.Marshal()` appears to have its own sorting
rules (per the struct it's sorting? [1] [2]); I'm not sure if it's going
to match js and python.

[1] https://stackoverflow.com/questions/18668652/how-to-produce-json-with-sorted-keys-in-go
[2] https://golang.org/pkg/encoding/json/#Marshal