### PR TITLE
Add map index support (js/python)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,16 +10,31 @@ implementations.
 
 ## JavaScript
 
+The JavaScript implementation is located in `./src`
+
 You should run `npm install` to install the required packages for JSON-e's
 execution and development.
 
+To run the tests use `npm test`
+
 ## Python
+
+The Python implementaion is located in `./jsone`.
 
 For Python, activate a virtualenv and run `pip install -e .`.
 
 To run the Python tests only, use `python setup.py test`.
 
 Note that JSON-e supports both Python 2 and Python 3.
+
+## Go
+
+The Go implementation is located in `./jsone.go` and `./interpreter`.
+
+To run the Go test run
+```
+GOPATH=$(pwd) go test -v -race ./...
+```
 
 # Demo development
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -31,6 +31,11 @@ Note that JSON-e supports both Python 2 and Python 3.
 
 The Go implementation is located in `./jsone.go` and `./interpreter`.
 
+Install dependencies:
+```
+GOPATH=$(pwd) go get -t ./...
+```
+
 To run the Go test run
 ```
 GOPATH=$(pwd) go test -v -race ./...

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,7 @@ docs/*
 build/
 dist/
 .hypothesis/
+
+# Go packages
+src/gopkg.in
+src/github.com

--- a/README.md
+++ b/README.md
@@ -312,14 +312,21 @@ template:
   each(x): {$eval: 'x + a'}
 context:  {a: 1}
 result:   [3, 5, 7]
+---
+template:
+  $map: [2, 4, 6]
+  each(x,i): {$eval: 'x + a + i'}
+context:  {a: 1}
+result:   [3, 6, 9]
 ```
 The array or object is the value of the `$map` property, and the expression to evaluate
-is given by `each(var)` where `var` is the name of the variable containing each
-element. In the case of iterating over an object, `var` will be an object with two keys:
-`key` and `val`. These keys correspond to a key in the object and its corresponding value.
+is given by `each(var[,key|index])` where `var` is the name of the variable containing each
+element and `key|index` is either the object key or array index of the value. In the case of 
+iterating over an object and no `key|index` var name is given, `var` will be an object with 
+two keys: `key` and `val`. These keys correspond to a key in the object and its corresponding value.
 
 When $map is given an object, the expression defined by `each(var)` must evaluate to an
-object for each key/value pair (`key` and `val`).The objects constructed by each 'each(var)'
+object for each key/value pair (`key` and `val`). The objects constructed by each 'each(var)'
 can then be merged internally to give the resulting object with later keys overwriting 
 the previous ones.Otherwise the expression becomes invalid for the $map operator
 
@@ -327,6 +334,12 @@ the previous ones.Otherwise the expression becomes invalid for the $map operator
 template:
   $map: {a: 1, b: 2, c: 3}
   each(y): {'${y.key}x': {$eval: 'y.val + 1'}}
+context:  {}
+result: {ax: 2, bx: 3, cx: 4}
+---
+template:
+  $map: {a: 1, b: 2, c: 3}
+  each(v,k): {'${k}x': {$eval: 'v + 1'}}
 context:  {}
 result: {ax: 2, bx: 3, cx: 4}
 ```

--- a/interpreter/util.go
+++ b/interpreter/util.go
@@ -242,7 +242,7 @@ func IsValidData(data interface{}) error {
 		return nil
 	}
 	switch val := data.(type) {
-	case *function, string, int, float64, bool:
+	case *function, string, float64, bool:
 		return nil
 	case []interface{}:
 		for _, value := range val {

--- a/interpreter/util.go
+++ b/interpreter/util.go
@@ -242,7 +242,7 @@ func IsValidData(data interface{}) error {
 		return nil
 	}
 	switch val := data.(type) {
-	case *function, string, float64, bool:
+	case *function, string, int, float64, bool:
 		return nil
 	case []interface{}:
 		for _, value := range val {

--- a/jsone.go
+++ b/jsone.go
@@ -492,7 +492,7 @@ var operators = map[string]operator{
 				}
 				c[eachIdentifier] = entry
 				if len(eachIndex) > 0 {
-					c[eachIndex] = idx
+					c[eachIndex] = float64(idx)
 				}
 				r, err := render(eachTemplate, c)
 				if err != nil {

--- a/jsone/newsfragments/235.feature
+++ b/jsone/newsfragments/235.feature
@@ -1,0 +1,15 @@
+Support of `index` or `key` context variable in `$map` operation.
+
+```yaml
+template:
+  $map: [2, 4, 6]
+  each(x,i): {$eval: 'x + a + i'}
+context:  {a: 1}
+result:   [3, 6, 9]
+---
+template:
+  $map: {a: 1, b: 2, c: 3}
+  each(v,k): {'${k}x': {$eval: 'v + 1'}}
+context:  {}
+result: {ax: 2, bx: 3, cx: 4}
+```

--- a/jsone/newsfragments/242.feature
+++ b/jsone/newsfragments/242.feature
@@ -1,0 +1,1 @@
+Add support for element indexes in $map

--- a/jsone/render.py
+++ b/jsone/render.py
@@ -182,15 +182,18 @@ def map(template, context):
     each_key = each_keys[0]
     each_args = [x.strip() for x in each_key[5:-1].split(',')]
     each_var = each_args[0]
-    each_idx, = each_args[1:2] or ['_index']
+    each_idx = each_args[1] if len(each_args) > 1 else None
 
     each_template = template[each_key]
 
     def gen(val):
         subcontext = context.copy()
         for i, elt in enumerate(val):
-            subcontext[each_var] = elt
-            subcontext[each_idx] = i
+            if each_idx is None:
+                subcontext[each_var] = elt
+            else:
+                subcontext[each_var] = elt['val'] if is_obj else elt
+                subcontext[each_idx] = elt['key'] if is_obj else i
             elt = renderValue(each_template, subcontext)
             if elt is not DeleteMarker:
                 yield elt

--- a/jsone/render.py
+++ b/jsone/render.py
@@ -167,7 +167,7 @@ def let(template, context):
 
 @operator('$map')
 def map(template, context):
-    EACH_RE = 'each\([a-zA-Z_][a-zA-Z0-9_]*\)'
+    EACH_RE = 'each\([a-zA-Z_][a-zA-Z0-9_]*(,\s*([a-zA-Z_][a-zA-Z0-9_]*))?\)'
     checkUndefinedProperties(template, ['\$map', EACH_RE])
     value = renderValue(template['$map'], context)
     if not isinstance(value, list) and not isinstance(value, dict):
@@ -180,13 +180,17 @@ def map(template, context):
         raise TemplateError(
             "$map requires exactly one other property, each(..)")
     each_key = each_keys[0]
-    each_var = each_key[5:-1]
+    each_args = [x.strip() for x in each_key[5:-1].split(',')]
+    each_var = each_args[0]
+    each_idx, = each_args[1:2] or ['_index']
+
     each_template = template[each_key]
 
     def gen(val):
         subcontext = context.copy()
-        for elt in val:
+        for i, elt in enumerate(val):
             subcontext[each_var] = elt
+            subcontext[each_idx] = i
             elt = renderValue(each_template, subcontext)
             if elt is not DeleteMarker:
                 yield elt

--- a/specification.yml
+++ b/specification.yml
@@ -795,6 +795,48 @@ template:
   each(y): {'${y.key}': {$eval: 'y.val'}, '${y.key}x': {$eval: 'y.val + 1'}}
 result: {a: 1, b: 2, c: 3, ax: 2, bx: 3, cx: 4}
 ---
+title:    $map array index variable
+context: {}
+template:
+  $map: ['a', 'b', 'c']
+  each(y,i): '${y}-${i}'
+result: ['a-0','b-1','c-2']
+---
+title:    $map array implicit index variable
+context: {}
+template:
+  $map: ['a', 'b', 'c']
+  each(y): '${y}-${_index}'
+result: ['a-0','b-1','c-2']
+---
+title:    $map map index variable
+context: {}
+template:
+  $map: {a: 1, b: 2, c: 3}
+  each(y, i): {'${y.key}':{$eval: 'y.val + i'}}
+result: {a: 1, b: 3, c: 5}
+---
+title:    $map map implicit index variable
+context: {}
+template:
+  $map: {a: 1, b: 2, c: 3}
+  each(y): {'${y.key}':{$eval: 'y.val + _index'}}
+result: {a: 1, b: 3, c: 5}
+---
+title:    $map no args
+context:  {}
+template:
+  $map: "a, b, c"
+  each(): {$eval: 'y.k'}
+error: 'TemplateError: $map has undefined properties: each()'
+---
+title:    $map to many args
+context:  {}
+template:
+  $map: "a, b, c"
+  each(k,v,i): {$eval: 'y.k'}
+error: 'TemplateError: $map has undefined properties: each(k,v,i)'
+---
 title:    $map requires an array, not string
 context:  {}
 template:

--- a/specification.yml
+++ b/specification.yml
@@ -781,11 +781,18 @@ template:
     then: {$eval: 'y.k'}
 result: [1, 3]
 ---
-title:    $map works on array or object
+title:    $map works on object
 context:  {}
 template:
   $map: {a: 1, b: 2, c: 3}
   each(y): {'${y.key}x': {$eval: 'y.val + 1'}}
+result: {ax: 2, bx: 3, cx: 4}
+---
+title:    $map each(value,key) on object
+context:  {}
+template:
+  $map: {a: 1, b: 2, c: 3}
+  each(v,k): {'${k}x': {$eval: 'v + 1'}}
 result: {ax: 2, bx: 3, cx: 4}
 ---
 title:    $map can add new keys to object
@@ -802,27 +809,6 @@ template:
   each(y,i): '${y}-${i}'
 result: ['a-0','b-1','c-2']
 ---
-title:    $map array implicit index variable
-context: {}
-template:
-  $map: ['a', 'b', 'c']
-  each(y): '${y}-${_index}'
-result: ['a-0','b-1','c-2']
----
-title:    $map map index variable
-context: {}
-template:
-  $map: {a: 1, b: 2, c: 3}
-  each(y, i): {'${y.key}':{$eval: 'y.val + i'}}
-result: {a: 1, b: 3, c: 5}
----
-title:    $map map implicit index variable
-context: {}
-template:
-  $map: {a: 1, b: 2, c: 3}
-  each(y): {'${y.key}':{$eval: 'y.val + _index'}}
-result: {a: 1, b: 3, c: 5}
----
 title:    $map no args
 context:  {}
 template:
@@ -830,7 +816,7 @@ template:
   each(): {$eval: 'y.k'}
 error: 'TemplateError: $map has undefined properties: each()'
 ---
-title:    $map to many args
+title:    $map too many args
 context:  {}
 template:
   $map: "a, b, c"

--- a/src/index.js
+++ b/src/index.js
@@ -153,7 +153,7 @@ operators.$let = (template, context) => {
 };
 
 operators.$map = (template, context) => {
-  EACH_RE = 'each\\(([a-zA-Z_][a-zA-Z0-9_]*)\\)';
+  EACH_RE = 'each\\(([a-zA-Z_][a-zA-Z0-9_]*)(,\\s*([a-zA-Z_][a-zA-Z0-9_]*))?\\)';
   checkUndefinedProperties(template, ['\\$map', EACH_RE]);
   let value = render(template['$map'], context);
   if (!isArray(value) && !isObject(value)) {
@@ -165,12 +165,14 @@ operators.$map = (template, context) => {
   }
 
   let eachKey = Object.keys(template).filter(k => k !== '$map')[0];
-  let match = /^each\(([a-zA-Z_][a-zA-Z0-9_]*)\)$/.exec(eachKey);
+  let match = /^each\(([a-zA-Z_][a-zA-Z0-9_]*)(,\s*([a-zA-Z_][a-zA-Z0-9_]*))?\)$/.exec(eachKey);
   if (!match) {
     throw new TemplateError('$map requires each(identifier) syntax');
   }
 
   let x = match[1];
+  let i = match[3] || '_index';
+  console.log(i);
   let each = template[eachKey];
 
   let object = isObject(value);
@@ -178,8 +180,8 @@ operators.$map = (template, context) => {
   if (object) {
     value = Object.keys(value).map(key => ({key, val: value[key]}));
     let eachValue;
-    value = value.map(v => {
-      eachValue = render(each, Object.assign({}, context, {[x]: v}));
+    value = value.map((v, idx) => {
+      eachValue = render(each, Object.assign({}, context, {[x]: v, [i]: idx}));
       if (!isObject(eachValue)) {
         throw new TemplateError(`$map on objects expects each(${x}) to evaluate to an object`);
       } 
@@ -188,7 +190,7 @@ operators.$map = (template, context) => {
     //return value.reduce((a, o) => Object.assign(a, o), {});
     return Object.assign({}, ...value);
   } else {
-    return value.map(v => render(each, Object.assign({}, context, {[x]: v})))
+    return value.map((v, idx) => render(each, Object.assign({}, context, {[x]: v, [i]: idx})))
       .filter(v => v !== deleteMarker);
   }
 };

--- a/src/index.js
+++ b/src/index.js
@@ -171,8 +171,7 @@ operators.$map = (template, context) => {
   }
 
   let x = match[1];
-  let i = match[3] || '_index';
-  console.log(i);
+  let i = match[3];
   let each = template[eachKey];
 
   let object = isObject(value);
@@ -180,8 +179,9 @@ operators.$map = (template, context) => {
   if (object) {
     value = Object.keys(value).map(key => ({key, val: value[key]}));
     let eachValue;
-    value = value.map((v, idx) => {
-      eachValue = render(each, Object.assign({}, context, {[x]: v, [i]: idx}));
+    value = value.map(v => {
+      let args = typeof i !== 'undefined' ? {[x]: v.val, [i]: v.key} : {[x]: v};
+      eachValue = render(each, Object.assign({}, context, args));
       if (!isObject(eachValue)) {
         throw new TemplateError(`$map on objects expects each(${x}) to evaluate to an object`);
       } 
@@ -190,8 +190,10 @@ operators.$map = (template, context) => {
     //return value.reduce((a, o) => Object.assign(a, o), {});
     return Object.assign({}, ...value);
   } else {
-    return value.map((v, idx) => render(each, Object.assign({}, context, {[x]: v, [i]: idx})))
-      .filter(v => v !== deleteMarker);
+    return value.map((v, idx) => {
+      let args = typeof i !== 'undefined' ? {[x]: v, [i]: idx} : {[x]: v};
+      return render(each, Object.assign({}, context, args));
+    }).filter(v => v !== deleteMarker);
   }
 };
 


### PR DESCRIPTION
Extend the $map operation to expose the value index as specified in #235 . An optional argument can be supplied to the "each" argument (i.e. each(val,index)). If no index argument is specified an implicit '_index' value will be added to the context.

