### PR TITLE
Remove flex from jsone playground codeblocks

### DIFF
--- a/demo/src/app.css
+++ b/demo/src/app.css
@@ -65,13 +65,7 @@ html, body, #root {
   flex: 1;
 }
 
-.codeblocks {
-  display: flex;
-  flex-direction: row;
-}
-
 .codeblocks > div {
-  flex: 1 1;
   padding: 0.5em;
 }
 


### PR DESCRIPTION
This causes the template, context, and results to align vertically, which works better when any of them has a long line (typically it prevents the output being squashed up against the right hand side).

*describe your pull request here*

# Checklist

Before submitting a pull request, please check the following:

* [ ] All tests pass for all implementations (all implementations must behave identically)
* [ ] New tests have been added for any new functionality or to prevent regressions of a bugfix
* [ ] Added a short description of the change to `newsfragments/$issue.bugfix` (for fixes) or `.feature` (for new features) or `.doc` (for documentation-only changes)
