### PR TITLE
[WIP] Add spec and implementation for $switch

### DIFF
--- a/specification.yml
+++ b/specification.yml
@@ -907,6 +907,60 @@ context:  {cond: 3, ifcond: false}
 template: {$match: {'cond == 3': {$if: 'ifcond', then: "t", else: "f"}}}
 result:   ["f"]
 ################################################################################
+---
+section: $switch operator
+---
+title:    $switch, one condition, one match
+context:  {cond: 3}
+template: {$switch: [{case: 'cond == 3', then: 2}], default: 5}
+result:   2
+---
+title:    $switch, two conditions, first match
+context:  {cond: 3}
+template: {$switch: [{case: 'cond == 3', then: 2},{case: 'cond == 4', then: 3}], default: 5}
+result:   2
+---
+title:    $switch, two conditions, second match
+context:  {cond: 4}
+template: {$switch: [{case: 'cond == 3', then: 2},{case: 'cond == 4', then: 3}], default: 5}
+result:   3
+---
+title:    $switch, two conditions, no match
+context:  {cond: 10}
+template: {$switch: [{case: 'cond == 3', then: 2},{case: 'cond == 4', then: 3}], default: 5}
+result:   5
+---
+title:    $switch, two conditions, no match, no default
+context:  {cond: 10}
+template: {$switch: [{case: 'cond == 3', then: 2},{case: 'cond == 4', then: 3}]}
+result:   null
+---
+title:    $switch, no conditions, no default
+context:  {cond: 10}
+template: {$switch: []}
+result:   null
+---
+title:    $switch, no conditions, default
+context:  {cond: 10}
+template: {$switch: [], default: 16}
+result:   16
+---
+title:    $switch with invalid cases
+context:  {}
+template: {$switch: [{case: true, if: true, then: 5}]}
+error: 'TemplateError: case has undefined properties: if'
+---
+title:    $switch with invalid cases (2)
+context:  {}
+template: {$switch: [{case: true}]}
+error: 'TemplateError: $switch cases must have both a `case` and a `then` clause'
+---
+title:    $switch with invalid cases (3)
+context:  {}
+template: {$switch: [{then: 10}]}
+error: 'TemplateError: $switch cases must have both a `case` and a `then` clause'
+################################################################################
+---
 section:  $merge
 ---
 title:    simple merge

--- a/src/index.js
+++ b/src/index.js
@@ -216,6 +216,29 @@ operators.$match = (template, context) => {
   return result;
 };
 
+operators.$switch = (template, context) => {
+  checkUndefinedProperties(template, ['\\$switch', 'default']);
+
+  if (!isArray(template['$switch'])) {
+    throw new TemplateError('$switch can evaluate arrays only');
+  }
+
+  template['$switch'].forEach(c => {
+    checkUndefinedProperties(c, ['case', 'then']);
+    if (c.case == undefined || c.then === undefined) {
+      throw new TemplateError('$switch cases must have both a `case` and a `then` clause');
+    }
+  });
+
+  for (let c of template['$switch']) {
+    if (isTruthy(interpreter.parse(c.case, context))) {
+      return render(c.then, context);
+    }
+  }
+
+  return template.hasOwnProperty('default') ? render(template['default'], context) : deleteMarker;
+};
+
 operators.$merge = (template, context) => {
   checkUndefinedProperties(template, ['\\$merge']);
 


### PR DESCRIPTION
This adds the `$switch` keyword discussed in #257. It is currently a WIP, but the basic idea is that you give it an array of possible cases and the first case that matches returns its value. If nothing matches, there is an optional `default` field as well.

# Checklist

Before submitting a pull request, please check the following:

* [ ] All tests pass for all implementations (all implementations must behave identically)
* [ ] New tests have been added for any new functionality or to prevent regressions of a bugfix
* [ ] Added a short description of the change to `newsfragments/$issue.bugfix` (for fixes) or `.feature` (for new features) or `.doc` (for documentation-only changes)
