### PR TITLE
remove uses of `assert` in non-testing code

### DIFF
--- a/jsone/newsfragments/266.bugfix
+++ b/jsone/newsfragments/266.bugfix
@@ -1,0 +1,1 @@
+Do not import `assert` in non-test code, so that it can run on browsers

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 var interpreter = require('./interpreter');
 var fromNow = require('./from-now');
-var assert = require('assert');
 var stringify = require('json-stable-stringify');
 var {
   isString, isNumber, isBool,

--- a/src/prattparser.js
+++ b/src/prattparser.js
@@ -4,7 +4,6 @@
 */
 
 var Tokenizer = require('./tokenizer');
-var assert = require('assert');
 var {isString} = require('./type-utils');
 var {SyntaxError, TemplateError} = require('./error');
 
@@ -36,7 +35,9 @@ class PrattParser {
     // Ensure we have precedence for all the kinds used in infixRules
     for (let kind of Object.keys(infixRules)) {
       if (infixRules.hasOwnProperty(kind)) {
-        assert(this._precedenceMap[kind], `token '${kind}' must have a precedence`);
+        if (!this._precedenceMap[kind]) {
+          throw new Error(`token '${kind}' must have a precedence`);
+        }
       }
     }
 

--- a/src/tokenizer.js
+++ b/src/tokenizer.js
@@ -1,4 +1,3 @@
-var assert = require('assert');
 var {SyntaxError} = require('./error');
 
 let escapeRegex = (s) => s.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
@@ -27,6 +26,16 @@ let indexOfNotUndefined = (a, start = 0) => {
     }
   }
   return -1;
+};
+
+/**
+ * Custom implementation of `assert` to avoid pulling in a
+ * polyfill on browsers
+ */
+const assert = prop => {
+  if (!prop) {
+    throw new Error('Token configuration is invalid');
+  }
 };
 
 class Tokenizer {


### PR DESCRIPTION
Per #266, we should avoid using `assert` in production code, as it is not defined on browsers.

