### PR TITLE
Update README.md to document the Pypi distribution name

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,13 @@ build such applications.
 
 ## Python
 
-The Python distribution exposes a `render` function:
+The Python distribution is installed with
+
+```shell
+pip install json-e
+```
+
+The distribution exposes a `render` function:
 
 ```python
 import jsone


### PR DESCRIPTION
As the module name `jsone` doesn't yields the distribution on Pypi when
searched, document the actual distribution name to ease installation.