### PR TITLE
Use json-stable-stringify-without-jsonify to avoid unlicensed libs

### DIFF
--- a/jsone/newsfragments/299.bugfix
+++ b/jsone/newsfragments/299.bugfix
@@ -1,0 +1,1 @@
+[JS] Use `json-stable-stringify-without-jsonify`, dropping use of the unlicensed `jsonify`.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "",
   "license": "MPL-2.0",
   "dependencies": {
-    "json-stable-stringify": "^1.0.1"
+    "json-stable-stringify-without-jsonify": "^1.0.1"
   },
   "devDependencies": {
     "assume": "^2.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 var interpreter = require('./interpreter');
 var fromNow = require('./from-now');
-var stringify = require('json-stable-stringify');
+var stringify = require('json-stable-stringify-without-jsonify');
 var {
   isString, isNumber, isBool,
   isArray, isObject,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1039,13 +1039,6 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
-json-stable-stringify@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
-  integrity sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=
-  dependencies:
-    jsonify "~0.0.0"
-
 json-stable-stringify@~0.0.0:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz#611c23e814db375527df851193db59dd2af27f45"


### PR DESCRIPTION
Fixes #299.

* [x] All tests pass for all implementations (all implementations must behave identically)
* (N/A) New tests have been added for any new functionality or to prevent regressions of a bugfix
* [x] Added a short description of the change to `newsfragments/$issue.bugfix` (for fixes) or `.feature` (for new features) or `.doc` (for documentation-only changes)
