### PR TITLE
Better error message when indexing string or array with non integer

### DIFF
--- a/jsone/interpreter.py
+++ b/jsone/interpreter.py
@@ -22,8 +22,11 @@ OPERATORS = {
 
 
 def infixExpectationError(operator, expected):
-    return InterpreterError('infix: {} expects {} {} {}'.
-                            format(operator, expected, operator, expected))
+    if operator == "[..]" and expected == "integer":
+        return InterpreterError('should only use integers to access arrays or strings')
+    else:
+        return InterpreterError('infix: {} expects {} {} {}'.
+                                format(operator, expected, operator, expected))
 
 
 class ExpressionEvaluator(PrattParser):

--- a/jsone/interpreter.py
+++ b/jsone/interpreter.py
@@ -272,14 +272,14 @@ def accessProperty(value, a, b, is_interval):
             try:
                 return value[a:b]
             except TypeError:
-                raise infixExpectationError('[..]', 'integer')
+                raise InterpreterError('should only use integers to access arrays or strings')
         else:
             try:
                 return value[a]
             except IndexError:
                 raise TemplateError('index out of bounds')
             except TypeError:
-                raise infixExpectationError('[..]', 'integer')
+                raise InterpreterError('should only use integers to access arrays or strings')
 
     if not isinstance(value, dict):
         raise infixExpectationError('[..]', 'object, array, or string')

--- a/jsone/interpreter.py
+++ b/jsone/interpreter.py
@@ -22,11 +22,8 @@ OPERATORS = {
 
 
 def infixExpectationError(operator, expected):
-    if operator == "[..]" and expected == "integer":
-        return InterpreterError('should only use integers to access arrays or strings')
-    else:
-        return InterpreterError('infix: {} expects {} {} {}'.
-                                format(operator, expected, operator, expected))
+    return InterpreterError('infix: {} expects {} {} {}'.
+                            format(operator, expected, operator, expected))
 
 
 class ExpressionEvaluator(PrattParser):

--- a/jsone/newsfragments/318.bugfix
+++ b/jsone/newsfragments/318.bugfix
@@ -1,0 +1,1 @@
+Better error message when indexing string or array with non integer

--- a/specification.yml
+++ b/specification.yml
@@ -5056,6 +5056,11 @@ context: {}
 template: {$eval: '3 >= "hello"'}
 error: 'InterpreterError: infix: >= expects numbers/strings >= numbers/strings'
 ---
+title: 'Infix access array or string with non-integer type error'
+context: {extra: {attributes: 'a string!'}}
+template: {$if: "extra.attributes['someattr'] == 'x'", then: true}
+error: 'InterpreterError: should only use integers to access arrays or strings'
+---
 title: 'Nested error has appropriate message'
 context: {}
 template: {foo: [1, {"123": [{$eval: 10}]}]}

--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -92,7 +92,7 @@ let accessProperty = (left, a, b, isInterval) => {
       return left.slice(a, b);
     }
     if (!isInteger(a)) {
-      throw new InterpreterError('should access arrays using integers only');
+      throw new InterpreterError('should only use integers to access arrays or strings');
     }
 
     // for -ve index access


### PR DESCRIPTION
*describe your pull request here*
* [fixing issue 318](https://github.com/taskcluster/json-e/issues/318). 
* error happens when indexing a string or an array with a non-integer.

# Checklist

Before submitting a pull request, please check the following:

* [ ] All tests pass for all implementations (all implementations must behave identically)
* [x] New tests have been added for any new functionality or to prevent regressions of a bugfix
* [x] Added a short description of the change to `newsfragments/$issue.bugfix` (for fixes) or `.feature` (for new features) or `.doc` (for documentation-only changes)
