### PR TITLE
Issue #283 Differentiate path/variable from the rest of the error message

### DIFF
--- a/jsone/interpreter.py
+++ b/jsone/interpreter.py
@@ -182,7 +182,7 @@ class ExpressionEvaluator(PrattParser):
             return left[k]
         except KeyError:
             raise TemplateError(
-                '{} not found in {}'.format(k, json.dumps(left)))
+                '"{}" not found in {}'.format(k, json.dumps(left)))
 
     @infix("(")
     def function_call(self, left, token, pc):

--- a/jsone/newsfragments/283.bugfix
+++ b/jsone/newsfragments/283.bugfix
@@ -1,0 +1,1 @@
+Differentiate path/variable from the rest of the error message

--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -255,7 +255,7 @@ infixRules['.'] = (left, token, ctx) => {
     if (left.hasOwnProperty(key)) {
       return left[key];
     }
-    throw new InterpreterError('object has no property ' + key);
+    throw new InterpreterError(`object has no property "${key}"`);
   }
   throw expectationError('infix: .', 'objects');
 };


### PR DESCRIPTION
Fix for #283 
Differentiate path/variable from the rest of the error message
JavaScript:
```
# From:
$ Uncaught InterpreterError: object has no property bar
# To:
$ Uncaught InterpreterError: object has no property "bar"
```
Python:
```
# From:
$ jsone.shared.TemplateError: TemplateError at template.a: bar not found in {"car": "zoo"}
# To:
$ jsone.shared.TemplateError: TemplateError at template.a: "bar" not found in {"car": "zoo"}
```
Go (no change needed)
```
$ jsone.TemplateError{Message:"object has no such property at 3 -> '.' in 'foo.bar'", Template:map[string]interface {}{"$eval":"foo.bar"}}
```

# Checklist

Before submitting a pull request, please check the following:

* [x] All tests pass for you on your machine for all implementations (all implementations must behave identically)
* [x] New tests have been added for any new functionality or to prevent regressions of a bugfix
* [x] Added a short description of the change to `newsfragments/$issue.bugfix` (for fixes) or `.feature` (for new features) or `.doc` (for documentation-only changes)
