### PR TITLE
Part fix for #168

### DIFF
--- a/jsone/builtins.py
+++ b/jsone/builtins.py
@@ -1,3 +1,4 @@
+# pylint: max-line-length=240
 from __future__ import absolute_import, print_function, unicode_literals
 
 import math
@@ -13,26 +14,25 @@ def build(context):
 
     def builtin(name, variadic=None, argument_tests=None, minArgs=None):
         def wrap(fn):
-            def bad(reason=None):
-                raise BuiltinError(
-                    (reason or 'invalid arguments to builtin: {}').format(name))
             if variadic:
                 def invoke(*args):
                     if minArgs:
                         if len(args) < minArgs:
-                            bad("invalid arguments to builtin: {}: expected at least 1 arguments")
+                            raise BuiltinError(
+                                'invalid arguments to builtin: {}: expected at least {} arguments'.format(name, minArgs)
+                            )
                     for arg in args:
                         if not variadic(arg):
-                            bad()
+                            raise BuiltinError('invalid arguments to builtin: {}'.format(name))
                     return fn(*args)
 
             elif argument_tests:
                 def invoke(*args):
                     if len(args) != len(argument_tests):
-                        bad()
+                        raise BuiltinError('invalid arguments to builtin: {}'.format(name))
                     for t, arg in zip(argument_tests, args):
                         if not t(arg):
-                            bad("invalid arguments to builtin: {}")
+                            raise BuiltinError('invalid arguments to builtin: {}'.format(name))
                     return fn(*args)
 
             else:

--- a/jsone/builtins.py
+++ b/jsone/builtins.py
@@ -20,7 +20,7 @@ def build(context):
                 def invoke(*args):
                     if minArgs:
                         if len(args) < minArgs:
-                            bad("too few arguments to {}")
+                            bad("invalid arguments to builtin: {}: expected at least 1 arguments")
                     for arg in args:
                         if not variadic(arg):
                             bad()
@@ -32,7 +32,7 @@ def build(context):
                         bad()
                     for t, arg in zip(argument_tests, args):
                         if not t(arg):
-                            bad()
+                            bad("invalid arguments to builtin: {}")
                     return fn(*args)
 
             else:

--- a/jsone/interpreter.py
+++ b/jsone/interpreter.py
@@ -181,8 +181,8 @@ class ExpressionEvaluator(PrattParser):
         try:
             return left[k]
         except KeyError:
-            raise TemplateError(
-                '"{}" not found in {}'.format(k, json.dumps(left)))
+            raise InterpreterError(
+                'object has no property {}'.format(k))
 
     @infix("(")
     def function_call(self, left, token, pc):
@@ -281,7 +281,8 @@ def accessProperty(value, a, b, is_interval):
     if not isinstance(value, dict):
         raise infixExpectationError('[..]', 'object, array, or string')
     if not isinstance(a, string):
-        raise infixExpectationError('[..]', 'string index')
+        # raise infixExpectationError('[..]', 'string index')
+        raise InterpreterError('object keys must be strings')
 
     try:
         return value[a]

--- a/jsone/interpreter.py
+++ b/jsone/interpreter.py
@@ -281,7 +281,6 @@ def accessProperty(value, a, b, is_interval):
     if not isinstance(value, dict):
         raise infixExpectationError('[..]', 'object, array, or string')
     if not isinstance(a, string):
-        # raise infixExpectationError('[..]', 'string index')
         raise InterpreterError('object keys must be strings')
 
     try:

--- a/jsone/interpreter.py
+++ b/jsone/interpreter.py
@@ -176,13 +176,13 @@ class ExpressionEvaluator(PrattParser):
     @infix(".")
     def property_dot(self, left, token, pc):
         if not isinstance(left, dict):
-            raise infixExpectationError('.', 'object')
+            raise InterpreterError('infix: . expects objects')
         k = pc.require('identifier').value
         try:
             return left[k]
         except KeyError:
             raise InterpreterError(
-                'object has no property {}'.format(k))
+                'object has no property "{}"'.format(k))
 
     @infix("(")
     def function_call(self, left, token, pc):
@@ -269,7 +269,7 @@ def accessProperty(value, a, b, is_interval):
             try:
                 return value[a:b]
             except TypeError:
-                raise InterpreterError('should only use integers to access arrays or strings')
+                raise InterpreterError('cannot perform interval access with non-integers')
         else:
             try:
                 return value[a]

--- a/jsone/interpreter.py
+++ b/jsone/interpreter.py
@@ -132,10 +132,10 @@ class ExpressionEvaluator(PrattParser):
     @infix("+")
     def plus(self, left, token, pc):
         if not isinstance(left, (string, int, float)) or isinstance(left, bool):
-            raise infixExpectationError('+', 'number/string')
+            raise infixExpectationError('+', 'numbers/strings')
         right = pc.parse(token.kind)
         if not isinstance(right, (string, int, float)) or isinstance(right, bool):
-            raise infixExpectationError('+', 'number/string')
+            raise infixExpectationError('+', 'numbers/strings')
         if type(right) != type(left) and \
                 (isinstance(left, string) or isinstance(right, string)):
             raise infixExpectationError('+', 'numbers/strings')

--- a/jsone/newsfragments/168.bugfix
+++ b/jsone/newsfragments/168.bugfix
@@ -1,0 +1,3 @@
+## Part fix for #168: Enforce all error messages match
+
+Made sure error messages for arithmetic operations, builtins, and strings are the same.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [pep8]
-max-line-length = 100
+max-line-length = 150
 select = E,W

--- a/specification.yml
+++ b/specification.yml
@@ -2245,7 +2245,7 @@ error: 'InterpreterError: infix: + expects numbers/strings + numbers/strings'
 title: 'addition of strings to objects'
 context: {a: 'a', b: {x: 1}}
 template: {$eval: 'a + b'}
-error: true
+error: 'InterpreterError: infix: + expects numbers/strings + numbers/strings'
 ---
 title: 'addition of strings to arrays'
 context: {a: 'a', b: [1, 2]}
@@ -2285,607 +2285,607 @@ error: 'InterpreterError: infix: - expects number - number'
 title: 'multiplication of strings to strings'
 context: {a: 'a', b: 'b'}
 template: {$eval: 'a * b'}
-error: true
+error: 'InterpreterError: infix: * expects number * number'
 ---
 title: 'multiplication of strings to numbers'
 context: {a: 'a', b: 1}
 template: {$eval: 'a * b'}
-error: true
+error: 'InterpreterError: infix: * expects number * number'
 ---
 title: 'multiplication of strings to null'
 context: {a: 'a', b: null}
 template: {$eval: 'a * b'}
-error: true
+error: 'InterpreterError: infix: * expects number * number'
 ---
 title: 'multiplication of strings to booleans'
 context: {a: 'a', b: true}
 template: {$eval: 'a * b'}
-error: true
+error: 'InterpreterError: infix: * expects number * number'
 ---
 title: 'multiplication of strings to objects'
 context: {a: 'a', b: {x: 1}}
 template: {$eval: 'a * b'}
-error: true
+error: 'InterpreterError: infix: * expects number * number'
 ---
 title: 'multiplication of strings to arrays'
 context: {a: 'a', b: [1, 2]}
 template: {$eval: 'a * b'}
-error: true
+error: 'InterpreterError: infix: * expects number * number'
 ---
 title: 'division of strings by strings'
 context: {a: 'a', b: 'b'}
 template: {$eval: 'a / b'}
-error: true
+error: 'InterpreterError: infix: / expects number / number'
 ---
 title: 'division of strings by numbers'
 context: {a: 'a', b: 1}
 template: {$eval: 'a / b'}
-error: true
+error: 'InterpreterError: infix: / expects number / number'
 ---
 title: 'division of strings by null'
 context: {a: 'a', b: null}
 template: {$eval: 'a / b'}
-error: true
+error: 'InterpreterError: infix: / expects number / number'
 ---
 title: 'division of strings by booleans'
 context: {a: 'a', b: true}
 template: {$eval: 'a / b'}
-error: true
+error: 'InterpreterError: infix: / expects number / number'
 ---
 title: 'division of strings by objects'
 context: {a: 'a', b: {x: 1}}
 template: {$eval: 'a / b'}
-error: true
+error: 'InterpreterError: infix: / expects number / number'
 ---
 title: 'division of strings by arrays'
 context: {a: 'a', b: [1, 2]}
 template: {$eval: 'a / b'}
-error: true
+error: 'InterpreterError: infix: / expects number / number'
 ---
 title: 'exponentiation of strings by strings'
 context: {a: 'a', b: 'b'}
 template: {$eval: 'a ** b'}
-error: true
+error: 'InterpreterError: infix: ** expects number ** number'
 ---
 title: 'exponentiation of strings by numbers'
 context: {a: 'a', b: 1}
 template: {$eval: 'a ** b'}
-error: true
+error: 'InterpreterError: infix: ** expects number ** number'
 ---
 title: 'exponentiation of strings by null'
 context: {a: 'a', b: null}
 template: {$eval: 'a ** b'}
-error: true
+error: 'InterpreterError: infix: ** expects number ** number'
 ---
 title: 'exponentiation of strings by booleans'
 context: {a: 'a', b: true}
 template: {$eval: 'a ** b'}
-error: true
+error: 'InterpreterError: infix: ** expects number ** number'
 ---
 title: 'exponentiation of strings by objects'
 context: {a: 'a', b: {x: 1}}
 template: {$eval: 'a ** b'}
-error: true
+error: 'InterpreterError: infix: ** expects number ** number'
 ---
 title: 'exponentiation of strings by arrays'
 context: {a: 'a', b: [1, 2]}
 template: {$eval: 'a ** b'}
-error: true
+error: 'InterpreterError: infix: ** expects number ** number'
 ---
 title: 'unary negation of string'
 context: {a: 'a'}
 template: {$eval: '-a'}
-error: true
+error: 'InterpreterError: unary - expects number'
 ---
 title: 'unary plus of string'
 context: {a: 'a'}
 template: {$eval: '+a'}
-error: true
+error: 'InterpreterError: unary + expects number'
 ---
 title:    'unary negation of true'
 template: {$eval: '-true'}
 context:  {}
-error:    true
+error:    'InterpreterError: unary - expects number'
 ---
 title:    'unary plus of true'
 template: {$eval: '+true'}
 context:  {}
-error:    true
+error:    'InterpreterError: unary + expects number'
 ---
 title:    'unary negation of false'
 template: {$eval: '-false'}
 context:  {}
-error:    true
+error:    'InterpreterError: unary - expects number'
 ---
 title:    'unary plus of false'
 template: {$eval: '+false'}
 context:  {}
-error:    true
+error:    'InterpreterError: unary + expects number'
 ---
 title:    'unary negation of null'
 template: {$eval: '-null'}
 context:  {}
-error:    true
+error:    'InterpreterError: unary - expects number'
 ---
 title:    'unary plus of null'
 template: {$eval: '+null'}
 context:  {}
-error:    true
+error:    'InterpreterError: unary + expects number'
 ---
 title: 'addition of numbers to strings'
 context: {a: 13, b: 'b'}
 template: {$eval: 'a + b'}
-error: true
+error: 'InterpreterError: infix: + expects numbers/strings + numbers/strings'
 ---
 title: 'addition of numbers to null'
 context: {a: 13, b: null}
 template: {$eval: 'a + b'}
-error: true
+error: 'InterpreterError: infix: + expects numbers/strings + numbers/strings'
 ---
 title: 'addition of numbers to booleans'
 context: {a: 13, b: true}
 template: {$eval: 'a + b'}
-error: true
+error: 'InterpreterError: infix: + expects numbers/strings + numbers/strings'
 ---
 title: 'addition of numbers to objects'
 context: {a: 13, b: {x: 1}}
 template: {$eval: 'a + b'}
-error: true
+error: 'InterpreterError: infix: + expects numbers/strings + numbers/strings'
 ---
 title: 'addition of numbers to arrays'
 context: {a: 13, b: [1, 2]}
 template: {$eval: 'a + b'}
-error: true
+error: 'InterpreterError: infix: + expects numbers/strings + numbers/strings'
 ---
 title: 'subtraction of numbers from strings'
 context: {a: 13, b: 'b'}
 template: {$eval: 'a-b'}
-error: true
+error: 'InterpreterError: infix: - expects number - number'
 ---
 title: 'subtraction of numbers from null'
 context: {a: 13, b: null}
 template: {$eval: 'a - b'}
-error: true
+error: 'InterpreterError: infix: - expects number - number'
 ---
 title: 'subtraction of numbers from booleans'
 context: {a: 13, b: true}
 template: {$eval: 'a - b'}
-error: true
+error: 'InterpreterError: infix: - expects number - number'
 ---
 title: 'subtraction of numbers from objects'
 context: {a: 13, b: {x: 1}}
 template: {$eval: 'a - b'}
-error: true
+error: 'InterpreterError: infix: - expects number - number'
 ---
 title: 'subtraction of numbers from arrays'
 context: {a: 13, b: [1, 2]}
 template: {$eval: 'a - b'}
-error: true
+error: 'InterpreterError: infix: - expects number - number'
 ---
 title: 'multiplication of numbers to strings'
 context: {a: 13, b: 'b'}
 template: {$eval: 'a * b'}
-error: true
+error: 'InterpreterError: infix: * expects number * number'
 ---
 title: 'multiplication of numbers to null'
 context: {a: 13, b: null}
 template: {$eval: 'a * b'}
-error: true
+error: 'InterpreterError: infix: * expects number * number'
 ---
 title: 'multiplication of numbers to booleans'
 context: {a: 13, b: true}
 template: {$eval: 'a * b'}
-error: true
+error: 'InterpreterError: infix: * expects number * number'
 ---
 title: 'multiplication of numbers to objects'
 context: {a: 13, b: {x: 1}}
 template: {$eval: 'a * b'}
-error: true
+error: 'InterpreterError: infix: * expects number * number'
 ---
 title: 'multiplication of numbers to arrays'
 context: {a: 13, b: [1, 2]}
-template: {$eval: 'a / b'}
-error: true
+template: {$eval: 'a * b'}
+error: 'InterpreterError: infix: * expects number * number'
 ---
 title: 'division of numbers by strings'
 context: {a: 13, b: 'b'}
 template: {$eval: 'a / b'}
-error: true
+error: 'InterpreterError: infix: / expects number / number'
 ---
 title: 'division of numbers by null'
 context: {a: 13, b: null}
 template: {$eval: 'a / b'}
-error: true
+error: 'InterpreterError: infix: / expects number / number'
 ---
 title: 'division of numbers by booleans'
 context: {a: 13, b: true}
 template: {$eval: 'a / b'}
-error: true
+error: 'InterpreterError: infix: / expects number / number'
 ---
 title: 'division of numbers by objects'
 context: {a: 13, b: {x: 1}}
 template: {$eval: 'a / b'}
-error: true
+error: 'InterpreterError: infix: / expects number / number'
 ---
 title: 'division of numbers by arrays'
 context: {a: 13, b: [1, 2]}
 template: {$eval: 'a / b'}
-error: true
+error: 'InterpreterError: infix: / expects number / number'
 ---
 title: 'exponentiation of numbers by strings'
 context: {a: 13, b: 'b'}
 template: {$eval: 'a ** b'}
-error: true
+error: 'InterpreterError: infix: ** expects number ** number'
 ---
 title: 'exponentiation of numbers by null'
 context: {a: 13, b: null}
 template: {$eval: 'a ** b'}
-error: true
+error: 'InterpreterError: infix: ** expects number ** number'
 ---
 title: 'exponentiation of numbers by booleans'
 context: {a: 13, b: true}
 template: {$eval: 'a ** b'}
-error: true
+error: 'InterpreterError: infix: ** expects number ** number'
 ---
 title: 'exponentiation of numbers by objects'
 context: {a: 13, b: {x: 1}}
 template: {$eval: 'a ** b'}
-error: true
+error: 'InterpreterError: infix: ** expects number ** number'
 ---
 title: 'exponentiation of numbers by arrays'
 context: {a: 13, b: [1, 2]}
 template: {$eval: 'a ** b'}
-error: true
+error: 'InterpreterError: infix: ** expects number ** number'
 ---
 title: 'addition of null to strings'
 context: {a: null, b: 'a'}
 template: {$eval: 'a + b'}
-error: true
+error: 'InterpreterError: infix: + expects numbers/strings + numbers/strings'
 ---
 title: 'addition of null to numbers'
 context: {a: null, b: 1}
 template: {$eval: 'a + b'}
-error: true
+error: 'InterpreterError: infix: + expects numbers/strings + numbers/strings'
 ---
 title: 'addition of null to null'
 context: {a: null, b: null}
 template: {$eval: 'a + b'}
-error: true
+error: 'InterpreterError: infix: + expects numbers/strings + numbers/strings'
 ---
 title: 'addition of null to booleans'
 context: {a: null, b: true}
 template: {$eval: 'a + b'}
-error: true
+error: 'InterpreterError: infix: + expects numbers/strings + numbers/strings'
 ---
 title: 'addition of null to objects'
 context: {a: null, b: {x: 1}}
 template: {$eval: 'a + b'}
-error: true
+error: 'InterpreterError: infix: + expects numbers/strings + numbers/strings'
 ---
 title: 'addition of null to arrays'
 context: {a: null, b: [1, 2]}
 template: {$eval: 'a + b'}
-error: true
+error: 'InterpreterError: infix: + expects numbers/strings + numbers/strings'
 ---
 title: 'subtraction of null from strings'
 context: {a: null, b: 'b'}
 template: {$eval: 'a-b'}
-error: true
+error: 'InterpreterError: infix: - expects number - number'
 ---
 title: 'subtraction of null from numbers'
 context: {a: null, b: 1}
 template: {$eval: 'a - b'}
-error: true
+error: 'InterpreterError: infix: - expects number - number'
 ---
 title: 'subtraction of null from null'
 context: {a: null, b: null}
 template: {$eval: 'a - b'}
-error: true
+error: 'InterpreterError: infix: - expects number - number'
 ---
 title: 'subtraction of null from booleans'
 context: {a: null, b: true}
 template: {$eval: 'a - b'}
-error: true
+error: 'InterpreterError: infix: - expects number - number'
 ---
 title: 'subtraction of null from objects'
 context: {a: null, b: {x: 1}}
 template: {$eval: 'a - b'}
-error: true
+error: 'InterpreterError: infix: - expects number - number'
 ---
 title: 'subtraction of null from arrays'
 context: {a: null, b: [1, 2]}
 template: {$eval: 'a - b'}
-error: true
+error: 'InterpreterError: infix: - expects number - number'
 ---
 title: 'multiplication of null to strings'
 context: {a: null, b: 'b'}
 template: {$eval: 'a * b'}
-error: true
+error: 'InterpreterError: infix: * expects number * number'
 ---
 title: 'multiplication of null to numbers'
 context: {a: null, b: 1}
 template: {$eval: 'a * b'}
-error: true
+error: 'InterpreterError: infix: * expects number * number'
 ---
 title: 'multiplication of null to null'
 context: {a: null, b: null}
 template: {$eval: 'a * b'}
-error: true
+error: 'InterpreterError: infix: * expects number * number'
 ---
 title: 'multiplication of null to booleans'
 context: {a: null, b: true}
 template: {$eval: 'a * b'}
-error: true
+error: 'InterpreterError: infix: * expects number * number'
 ---
 title: 'multiplication of null to objects'
 context: {a: null, b: {x: 1}}
 template: {$eval: 'a * b'}
-error: true
+error: 'InterpreterError: infix: * expects number * number'
 ---
 title: 'multiplication of null to arrays'
 context: {a: null, b: [1, 2]}
-template: {$eval: 'a / b'}
-error: true
+template: {$eval: 'a * b'}
+error: 'InterpreterError: infix: * expects number * number'
 ---
 title: 'division of null by strings'
 context: {a: null, b: 'b'}
 template: {$eval: 'a / b'}
-error: true
+error: 'InterpreterError: infix: / expects number / number'
 ---
 title: 'division of null by numbers'
 context: {a: null, b: 1}
 template: {$eval: 'a / b'}
-error: true
+error: 'InterpreterError: infix: / expects number / number'
 ---
 title: 'division of null by null'
 context: {a: null, b: null}
 template: {$eval: 'a / b'}
-error: true
+error: 'InterpreterError: infix: / expects number / number'
 ---
 title: 'division of null by booleans'
 context: {a: null, b: true}
 template: {$eval: 'a / b'}
-error: true
+error: 'InterpreterError: infix: / expects number / number'
 ---
 title: 'division of null by objects'
 context: {a: null, b: {x: 1}}
 template: {$eval: 'a / b'}
-error: true
+error: 'InterpreterError: infix: / expects number / number'
 ---
 title: 'division of null by arrays'
 context: {a: null, b: [1, 2]}
 template: {$eval: 'a / b'}
-error: true
+error: 'InterpreterError: infix: / expects number / number'
 ---
 title: 'exponentiation of null by strings'
 context: {a: null, b: 'b'}
 template: {$eval: 'a ** b'}
-error: true
+error: 'InterpreterError: infix: ** expects number ** number'
 ---
 title: 'exponentiation of null by numbers'
 context: {a: null, b: 1}
 template: {$eval: 'a ** b'}
-error: true
+error: 'InterpreterError: infix: ** expects number ** number'
 ---
 title: 'exponentiation of null by null'
 context: {a: null, b: null}
 template: {$eval: 'a ** b'}
-error: true
+error: 'InterpreterError: infix: ** expects number ** number'
 ---
 title: 'exponentiation of null by booleans'
 context: {a: null, b: true}
 template: {$eval: 'a ** b'}
-error: true
+error: 'InterpreterError: infix: ** expects number ** number'
 ---
 title: 'exponentiation of null by objects'
 context: {a: null, b: {x: 1}}
 template: {$eval: 'a ** b'}
-error: true
+error: 'InterpreterError: infix: ** expects number ** number'
 ---
 title: 'exponentiation of null by arrays'
 context: {a: null, b: [1, 2]}
 template: {$eval: 'a ** b'}
-error: true
+error: 'InterpreterError: infix: ** expects number ** number'
 ---
 title: 'unary negation of null'
 context: {a: null}
 template: {$eval: '-a'}
-error: true
+error: 'InterpreterError: unary - expects number'
 ---
 title: 'unary plus of null'
 context: {a: null}
 template: {$eval: '+a'}
-error: true
+error: 'InterpreterError: unary + expects number'
 ---
 title: 'addition of boolean to strings'
 context: {a: true, b: 'a'}
 template: {$eval: 'a + b'}
-error: true
+error: 'InterpreterError: infix: + expects numbers/strings + numbers/strings'
 ---
 title: 'addition of boolean to numbers'
 context: {a: true, b: 1}
 template: {$eval: 'a + b'}
-error: true
+error: 'InterpreterError: infix: + expects numbers/strings + numbers/strings'
 ---
 title: 'addition of boolean to null'
 context: {a: true, b: null}
 template: {$eval: 'a + b'}
-error: true
+error: 'InterpreterError: infix: + expects numbers/strings + numbers/strings'
 ---
 title: 'addition of boolean to booleans'
 context: {a: true, b: true}
 template: {$eval: 'a + b'}
-error: true
+error: 'InterpreterError: infix: + expects numbers/strings + numbers/strings'
 ---
 title: 'addition of boolean to objects'
 context: {a: true, b: {x: 1}}
 template: {$eval: 'a + b'}
-error: true
+error: 'InterpreterError: infix: + expects numbers/strings + numbers/strings'
 ---
 title: 'addition of boolean to arrays'
 context: {a: true, b: [1, 2]}
 template: {$eval: 'a + b'}
-error: true
+error: 'InterpreterError: infix: + expects numbers/strings + numbers/strings'
 ---
 title: 'subtraction of boolean from strings'
 context: {a: true, b: 'b'}
 template: {$eval: 'a-b'}
-error: true
+error: 'InterpreterError: infix: - expects number - number'
 ---
 title: 'subtraction of boolean from numbers'
 context: {a: true, b: 1}
 template: {$eval: 'a - b'}
-error: true
+error: 'InterpreterError: infix: - expects number - number'
 ---
 title: 'subtraction of boolean from null'
 context: {a: true, b: null}
 template: {$eval: 'a - b'}
-error: true
+error: 'InterpreterError: infix: - expects number - number'
 ---
 title: 'subtraction of boolean from booleans'
 context: {a: true, b: true}
 template: {$eval: 'a - b'}
-error: true
+error: 'InterpreterError: infix: - expects number - number'
 ---
 title: 'subtraction of boolean from objects'
 context: {a: true, b: {x: 1}}
 template: {$eval: 'a - b'}
-error: true
+error: 'InterpreterError: infix: - expects number - number'
 ---
 title: 'subtraction of boolean from arrays'
 context: {a: true, b: [1, 2]}
 template: {$eval: 'a - b'}
-error: true
+error: 'InterpreterError: infix: - expects number - number'
 ---
 title: 'multiplication of boolean to strings'
 context: {a: true, b: 'b'}
 template: {$eval: 'a * b'}
-error: true
+error: 'InterpreterError: infix: * expects number * number'
 ---
 title: 'multiplication of boolean to numbers'
 context: {a: true, b: 1}
 template: {$eval: 'a * b'}
-error: true
+error: 'InterpreterError: infix: * expects number * number'
 ---
 title: 'multiplication of boolean to null'
 context: {a: true, b: null}
 template: {$eval: 'a * b'}
-error: true
+error: 'InterpreterError: infix: * expects number * number'
 ---
 title: 'multiplication of boolean to booleans'
 context: {a: true, b: true}
 template: {$eval: 'a * b'}
-error: true
+error: 'InterpreterError: infix: * expects number * number'
 ---
 title: 'multiplication of boolean to objects'
 context: {a: true, b: {x: 1}}
 template: {$eval: 'a * b'}
-error: true
+error: 'InterpreterError: infix: * expects number * number'
 ---
 title: 'multiplication of boolean to arrays'
 context: {a: true, b: [1, 2]}
-template: {$eval: 'a / b'}
-error: true
+template: {$eval: 'a * b'}
+error: 'InterpreterError: infix: * expects number * number'
 ---
 title: 'division of boolean by strings'
 context: {a: true, b: 'b'}
 template: {$eval: 'a / b'}
-error: true
+error: 'InterpreterError: infix: / expects number / number'
 ---
 title: 'division of boolean by numbers'
 context: {a: true, b: 1}
 template: {$eval: 'a / b'}
-error: true
+error: 'InterpreterError: infix: / expects number / number'
 ---
 title: 'division of boolean by null'
 context: {a: true, b: null}
 template: {$eval: 'a / b'}
-error: true
+error: 'InterpreterError: infix: / expects number / number'
 ---
 title: 'division of boolean by booleans'
 context: {a: true, b: true}
 template: {$eval: 'a / b'}
-error: true
+error: 'InterpreterError: infix: / expects number / number'
 ---
 title: 'division of boolean by objects'
 context: {a: true, b: {x: 1}}
 template: {$eval: 'a / b'}
-error: true
+error: 'InterpreterError: infix: / expects number / number'
 ---
 title: 'division of boolean by arrays'
 context: {a: true, b: [1, 2]}
 template: {$eval: 'a / b'}
-error: true
+error: 'InterpreterError: infix: / expects number / number'
 ---
 title: 'exponentiation of boolean by strings'
 context: {a: true, b: 'b'}
 template: {$eval: 'a ** b'}
-error: true
+error: 'InterpreterError: infix: ** expects number ** number'
 ---
 title: 'exponentiation of boolean by numbers'
 context: {a: true, b: 1}
 template: {$eval: 'a ** b'}
-error: true
+error: 'InterpreterError: infix: ** expects number ** number'
 ---
 title: 'exponentiation of boolean by null'
 context: {a: true, b: null}
 template: {$eval: 'a ** b'}
-error: true
+error: 'InterpreterError: infix: ** expects number ** number'
 ---
 title: 'exponentiation of boolean by booleans'
 context: {a: true, b: true}
 template: {$eval: 'a ** b'}
-error: true
+error: 'InterpreterError: infix: ** expects number ** number'
 ---
 title: 'exponentiation of boolean by objects'
 context: {a: true, b: {x: 1}}
 template: {$eval: 'a ** b'}
-error: true
+error: 'InterpreterError: infix: ** expects number ** number'
 ---
 title: 'exponentiation of boolean by arrays'
 context: {a: true, b: [1, 2]}
 template: {$eval: 'a ** b'}
-error: true
+error: 'InterpreterError: infix: ** expects number ** number'
 ---
 title: 'unary negation of boolean'
 context: {a: true}
 template: {$eval: '-a'}
-error: true
+error: 'InterpreterError: unary - expects number'
 ---
 title: 'unary plus of boolean'
 context: {a: true}
 template: {$eval: '+a'}
-error: true
+error: 'InterpreterError: unary + expects number'
 ---
 title: 'addition of object to strings'
 context: {a: {x: 10}, b: 'a'}
 template: {$eval: 'a + b'}
-error: true
+error: 'InterpreterError: infix: + expects numbers/strings + numbers/strings'
 ---
 title: 'addition of object to numbers'
 context: {a: {x: 10}, b: 1}
 template: {$eval: 'a + b'}
-error: true
+error: 'InterpreterError: infix: + expects numbers/strings + numbers/strings'
 ---
 title: 'addition of object to null'
 context: {a: {x: 10}, b: null}
 template: {$eval: 'a + b'}
-error: true
+error: 'InterpreterError: infix: + expects numbers/strings + numbers/strings'
 ---
 title: 'addition of object to booleans'
 context: {a: {x: 10}, b: true}
 template: {$eval: 'a + b'}
-error: true
+error: 'InterpreterError: infix: + expects numbers/strings + numbers/strings'
 ---
 title: 'addition of object to objects'
 context: {a: {x: 10}, b: {x: 1}}
 template: {$eval: 'a + b'}
-error: true
+error: 'InterpreterError: infix: + expects numbers/strings + numbers/strings'
 ---
 title: 'addition of object to arrays'
 context: {a: {x: 10}, b: [1, 2]}
 template: {$eval: 'a + b'}
-error: true
+error: 'InterpreterError: infix: + expects numbers/strings + numbers/strings'
 ---
 title: 'subtraction of object from strings'
 context: {a: {x: 10}, b: 'b'}

--- a/specification.yml
+++ b/specification.yml
@@ -3761,17 +3761,17 @@ error: 'InterpreterError: infix: [..] expects integer [..] integer'
 title: 'string length attribute is an error'
 context: {key: '12345'}
 template: {$eval: 'key.length'}
-error: true
+error: 'InterpreterError: infix: . expects object . object'
 ---
 title: 'string length attribute is an error even by index'
 context: {key: '12345'}
 template: {$eval: 'key["length"]'}
-error: true
+error: 'InterpreterError: infix: [..] expects integer [..] integer'
 ---
 title: 'other string attributes are not set'
 context: {key: 'abc'}
 template: {$eval: 'key.toUpperCase()'}
-error: true
+error: 'InterpreterError: infix: . expects object . object'
 ################################################################################
 ---
 section: expression language - property access
@@ -3804,7 +3804,7 @@ result: 'null'
 title: 'missing property'
 context: {key: {a: 1}}
 template: {$eval: 'key.b'}
-error: true
+error: 'InterpreterError: object has no property b'
 ---
 title: 'missing property by name'
 context: {key: {a: 1}}
@@ -3831,27 +3831,27 @@ context:
   obj: {'13': 15}
   key: 13 # note that this is the number 13, yet the object key is a string as required by JSON
 template: {$eval: 'obj[key]'}
-error: true
+error: 'InterpreterError: object keys must be strings'
 ---
 title: 'property of number'
 context: {key: 123}
 template: {$eval: 'key.valueOf'}
-error: true
+error: 'InterpreterError: infix: . expects object . object'
 ---
 title: 'property of null'
 context: {key: null}
 template: {$eval: 'key.foo'}
-error: true
+error: 'InterpreterError: infix: . expects object . object'
 ---
 title: 'property of boolean'
 context: {key: null}
 template: {$eval: 'key.valueOf'}
-error: true
+error: 'InterpreterError: infix: . expects object . object'
 ---
 title: 'property of array'
 context: {key: []}
 template: {$eval: 'key.valueOf'}
-error: true
+error: 'InterpreterError: infix: . expects object . object'
 ################################################################################
 ---
 section: expression language - array access

--- a/specification.yml
+++ b/specification.yml
@@ -3721,7 +3721,7 @@ result: '4'
 title: 'string indexing (noninteger)'
 context: {}
 template: {$eval: '"12345"[2.5]'}
-error: 'InterpreterError: infix: [..] expects integer [..] integer'
+error: 'InterpreterError: should only use integers to access arrays or strings'
 ---
 title: 'string slicing (1)'
 context: {key: '12345'}
@@ -3736,27 +3736,27 @@ result: '45'
 title: 'string slicing (noninteger first index)'
 context: {key: '12345'}
 template: {$eval: 'key[1.5:3]'}
-error: 'InterpreterError: infix: [..] expects integer [..] integer'
+error: 'InterpreterError: should only use integers to access arrays or strings'
 ---
 title: 'string slicing (noninteger second index)'
 context: {key: '12345'}
 template: {$eval: 'key[1:3.5]'}
-error: 'InterpreterError: infix: [..] expects integer [..] integer'
+error: 'InterpreterError: should only use integers to access arrays or strings'
 ---
 title: 'string slicing (noninteger indexes)'
 context: {key: '12345'}
 template: {$eval: 'key[1.5:3.5]'}
-error: 'InterpreterError: infix: [..] expects integer [..] integer'
+error: 'InterpreterError: should only use integers to access arrays or strings'
 ---
 title: 'string slicing type error (1)'
 context: {key: '12345'}
 template: {$eval: 'key["a":]'}
-error: 'InterpreterError: infix: [..] expects integer [..] integer'
+error: 'InterpreterError: should only use integers to access arrays or strings'
 ---
 title: 'string slicing type error (2)'
 context: {key: '12345'}
 template: {$eval: 'key[:"a"]'}
-error: 'InterpreterError: infix: [..] expects integer [..] integer'
+error: 'InterpreterError: should only use integers to access arrays or strings'
 ---
 title: 'string length attribute is an error'
 context: {key: '12345'}
@@ -3766,7 +3766,7 @@ error: 'InterpreterError: infix: . expects object . object'
 title: 'string length attribute is an error even by index'
 context: {key: '12345'}
 template: {$eval: 'key["length"]'}
-error: 'InterpreterError: infix: [..] expects integer [..] integer'
+error: 'InterpreterError: should only use integers to access arrays or strings'
 ---
 title: 'other string attributes are not set'
 context: {key: 'abc'}

--- a/specification.yml
+++ b/specification.yml
@@ -3681,22 +3681,22 @@ result: 'ab'
 title: 'TypeError: string + number (1)'
 context: {a: 3, b: 2}
 template: {$eval: '"a" + b'}
-error: true
+error: 'InterpreterError: infix: + expects numbers/strings + numbers/strings'
 ---
 title: 'TypeError: string + number (2)'
 context: {a: 3, b: 2}
 template: {$eval: '"" + a + b'}
-error: true
+error: 'InterpreterError: infix: + expects numbers/strings + numbers/strings'
 ---
 title: 'TypeError: string + number (3)'
 context: {a: 3, b: 2}
 template: {$eval: '"" + (a + b)'}
-error: true
+error: 'InterpreterError: infix: + expects numbers/strings + numbers/strings'
 ---
 title: 'TypeError: number + string (4)'
 context: {a: 3, b: 2}
 template: {$eval: '(a + b) + "abc"'}
-error: true
+error: 'InterpreterError: infix: + expects numbers/strings + numbers/strings'
 ---
 title: 'string indexing (1)'
 context: {key: '12345'}
@@ -3721,7 +3721,7 @@ result: '4'
 title: 'string indexing (noninteger)'
 context: {}
 template: {$eval: '"12345"[2.5]'}
-error: true
+error: 'InterpreterError: infix: [..] expects integer [..] integer'
 ---
 title: 'string slicing (1)'
 context: {key: '12345'}
@@ -3736,27 +3736,27 @@ result: '45'
 title: 'string slicing (noninteger first index)'
 context: {key: '12345'}
 template: {$eval: 'key[1.5:3]'}
-error: true
+error: 'InterpreterError: infix: [..] expects integer [..] integer'
 ---
 title: 'string slicing (noninteger second index)'
 context: {key: '12345'}
 template: {$eval: 'key[1:3.5]'}
-error: true
+error: 'InterpreterError: infix: [..] expects integer [..] integer'
 ---
 title: 'string slicing (noninteger indexes)'
 context: {key: '12345'}
 template: {$eval: 'key[1.5:3.5]'}
-error: true
+error: 'InterpreterError: infix: [..] expects integer [..] integer'
 ---
 title: 'string slicing type error (1)'
 context: {key: '12345'}
 template: {$eval: 'key["a":]'}
-error: true
+error: 'InterpreterError: infix: [..] expects integer [..] integer'
 ---
 title: 'string slicing type error (2)'
 context: {key: '12345'}
 template: {$eval: 'key[:"a"]'}
-error: true
+error: 'InterpreterError: infix: [..] expects integer [..] integer'
 ---
 title: 'string length attribute is an error'
 context: {key: '12345'}

--- a/specification.yml
+++ b/specification.yml
@@ -3736,32 +3736,32 @@ result: '45'
 title: 'string slicing (noninteger first index)'
 context: {key: '12345'}
 template: {$eval: 'key[1.5:3]'}
-error: 'InterpreterError: should only use integers to access arrays or strings'
+error: 'InterpreterError: cannot perform interval access with non-integers'
 ---
 title: 'string slicing (noninteger second index)'
 context: {key: '12345'}
 template: {$eval: 'key[1:3.5]'}
-error: 'InterpreterError: should only use integers to access arrays or strings'
+error: 'InterpreterError: cannot perform interval access with non-integers'
 ---
 title: 'string slicing (noninteger indexes)'
 context: {key: '12345'}
 template: {$eval: 'key[1.5:3.5]'}
-error: 'InterpreterError: should only use integers to access arrays or strings'
+error: 'InterpreterError: cannot perform interval access with non-integers'
 ---
 title: 'string slicing type error (1)'
 context: {key: '12345'}
 template: {$eval: 'key["a":]'}
-error: 'InterpreterError: should only use integers to access arrays or strings'
+error: 'InterpreterError: cannot perform interval access with non-integers'
 ---
 title: 'string slicing type error (2)'
 context: {key: '12345'}
 template: {$eval: 'key[:"a"]'}
-error: 'InterpreterError: should only use integers to access arrays or strings'
+error: 'InterpreterError: cannot perform interval access with non-integers'
 ---
 title: 'string length attribute is an error'
 context: {key: '12345'}
 template: {$eval: 'key.length'}
-error: 'InterpreterError: infix: . expects object . object'
+error: 'InterpreterError: infix: . expects objects'
 ---
 title: 'string length attribute is an error even by index'
 context: {key: '12345'}
@@ -3771,7 +3771,7 @@ error: 'InterpreterError: should only use integers to access arrays or strings'
 title: 'other string attributes are not set'
 context: {key: 'abc'}
 template: {$eval: 'key.toUpperCase()'}
-error: 'InterpreterError: infix: . expects object . object'
+error: 'InterpreterError: infix: . expects objects'
 ################################################################################
 ---
 section: expression language - property access
@@ -3804,7 +3804,7 @@ result: 'null'
 title: 'missing property'
 context: {key: {a: 1}}
 template: {$eval: 'key.b'}
-error: 'InterpreterError: object has no property b'
+error: 'InterpreterError: object has no property "b"'
 ---
 title: 'missing property by name'
 context: {key: {a: 1}}
@@ -3836,22 +3836,22 @@ error: 'InterpreterError: object keys must be strings'
 title: 'property of number'
 context: {key: 123}
 template: {$eval: 'key.valueOf'}
-error: 'InterpreterError: infix: . expects object . object'
+error: 'InterpreterError: infix: . expects objects'
 ---
 title: 'property of null'
 context: {key: null}
 template: {$eval: 'key.foo'}
-error: 'InterpreterError: infix: . expects object . object'
+error: 'InterpreterError: infix: . expects objects'
 ---
 title: 'property of boolean'
 context: {key: null}
 template: {$eval: 'key.valueOf'}
-error: 'InterpreterError: infix: . expects object . object'
+error: 'InterpreterError: infix: . expects objects'
 ---
 title: 'property of array'
 context: {key: []}
 template: {$eval: 'key.valueOf'}
-error: 'InterpreterError: infix: . expects object . object'
+error: 'InterpreterError: infix: . expects objects'
 ################################################################################
 ---
 section: expression language - array access

--- a/specification.yml
+++ b/specification.yml
@@ -2235,12 +2235,12 @@ error: 'InterpreterError: infix: + expects numbers/strings + numbers/strings'
 title: 'addition of strings to null'
 context: {a: 'a', b: null}
 template: {$eval: 'a + b'}
-error: true
+error: 'InterpreterError: infix: + expects numbers/strings + numbers/strings'
 ---
 title: 'addition of strings to booleans'
 context: {a: 'a', b: true}
 template: {$eval: 'a + b'}
-error: true
+error: 'InterpreterError: infix: + expects numbers/strings + numbers/strings'
 ---
 title: 'addition of strings to objects'
 context: {a: 'a', b: {x: 1}}
@@ -2250,37 +2250,37 @@ error: true
 title: 'addition of strings to arrays'
 context: {a: 'a', b: [1, 2]}
 template: {$eval: 'a + b'}
-error: true
+error: 'InterpreterError: infix: + expects numbers/strings + numbers/strings'
 ---
 title: 'subtraction of strings from strings'
 context: {a: 'a', b: 'b'}
 template: {$eval: 'a-b'}
-error: true
+error: 'InterpreterError: infix: - expects number - number'
 ---
 title: 'subtraction of strings from numbers'
 context: {a: 'a', b: 1}
 template: {$eval: 'a - b'}
-error: true
+error: 'InterpreterError: infix: - expects number - number'
 ---
 title: 'subtraction of strings from null'
 context: {a: 'a', b: null}
 template: {$eval: 'a - b'}
-error: true
+error: 'InterpreterError: infix: - expects number - number'
 ---
 title: 'subtraction of strings from booleans'
 context: {a: 'a', b: true}
 template: {$eval: 'a - b'}
-error: true
+error: 'InterpreterError: infix: - expects number - number'
 ---
 title: 'subtraction of strings from objects'
 context: {a: 'a', b: {x: 1}}
 template: {$eval: 'a - b'}
-error: true
+error: 'InterpreterError: infix: - expects number - number'
 ---
 title: 'subtraction of strings from arrays'
 context: {a: 'a', b: [1, 2]}
 template: {$eval: 'a - b'}
-error: true
+error: 'InterpreterError: infix: - expects number - number'
 ---
 title: 'multiplication of strings to strings'
 context: {a: 'a', b: 'b'}

--- a/specification.yml
+++ b/specification.yml
@@ -2890,292 +2890,292 @@ error: 'InterpreterError: infix: + expects numbers/strings + numbers/strings'
 title: 'subtraction of object from strings'
 context: {a: {x: 10}, b: 'b'}
 template: {$eval: 'a-b'}
-error: true
+error: 'InterpreterError: infix: - expects number - number'
 ---
 title: 'subtraction of object from numbers'
 context: {a: {x: 10}, b: 1}
 template: {$eval: 'a - b'}
-error: true
+error: 'InterpreterError: infix: - expects number - number'
 ---
 title: 'subtraction of object from null'
 context: {a: {x: 10}, b: null}
 template: {$eval: 'a - b'}
-error: true
+error: 'InterpreterError: infix: - expects number - number'
 ---
 title: 'subtraction of object from booleans'
 context: {a: {x: 10}, b: true}
 template: {$eval: 'a - b'}
-error: true
+error: 'InterpreterError: infix: - expects number - number'
 ---
 title: 'subtraction of object from objects'
 context: {a: {x: 10}, b: {x: 1}}
 template: {$eval: 'a - b'}
-error: true
+error: 'InterpreterError: infix: - expects number - number'
 ---
 title: 'subtraction of object from arrays'
 context: {a: {x: 10}, b: [1, 2]}
 template: {$eval: 'a - b'}
-error: true
+error: 'InterpreterError: infix: - expects number - number'
 ---
 title: 'multiplication of object to strings'
 context: {a: {x: 10}, b: 'b'}
 template: {$eval: 'a * b'}
-error: true
+error: 'InterpreterError: infix: * expects number * number'
 ---
 title: 'multiplication of object to numbers'
 context: {a: {x: 10}, b: 1}
 template: {$eval: 'a * b'}
-error: true
+error: 'InterpreterError: infix: * expects number * number'
 ---
 title: 'multiplication of object to null'
 context: {a: {x: 10}, b: null}
 template: {$eval: 'a * b'}
-error: true
+error: 'InterpreterError: infix: * expects number * number'
 ---
 title: 'multiplication of object to booleans'
 context: {a: {x: 10}, b: true}
 template: {$eval: 'a * b'}
-error: true
+error: 'InterpreterError: infix: * expects number * number'
 ---
 title: 'multiplication of object to objects'
 context: {a: {x: 10}, b: {x: 1}}
 template: {$eval: 'a * b'}
-error: true
+error: 'InterpreterError: infix: * expects number * number'
 ---
 title: 'multiplication of object to arrays'
 context: {a: {x: 10}, b: [1, 2]}
-template: {$eval: 'a / b'}
-error: true
+template: {$eval: 'a * b'}
+error: 'InterpreterError: infix: * expects number * number'
 ---
 title: 'division of object by strings'
 context: {a: {x: 10}, b: 'b'}
 template: {$eval: 'a / b'}
-error: true
+error: 'InterpreterError: infix: / expects number / number'
 ---
 title: 'division of object by numbers'
 context: {a: {x: 10}, b: 1}
 template: {$eval: 'a / b'}
-error: true
+error: 'InterpreterError: infix: / expects number / number'
 ---
 title: 'division of object by null'
 context: {a: {x: 10}, b: null}
 template: {$eval: 'a / b'}
-error: true
+error: 'InterpreterError: infix: / expects number / number'
 ---
 title: 'division of object by booleans'
 context: {a: {x: 10}, b: true}
 template: {$eval: 'a / b'}
-error: true
+error: 'InterpreterError: infix: / expects number / number'
 ---
 title: 'division of object by objects'
 context: {a: {x: 10}, b: {x: 1}}
 template: {$eval: 'a / b'}
-error: true
+error: 'InterpreterError: infix: / expects number / number'
 ---
 title: 'division of object by arrays'
 context: {a: {x: 10}, b: [1, 2]}
 template: {$eval: 'a / b'}
-error: true
+error: 'InterpreterError: infix: / expects number / number'
 ---
 title: 'exponentiation of object by strings'
 context: {a: {x: 10}, b: 'b'}
 template: {$eval: 'a ** b'}
-error: true
+error: 'InterpreterError: infix: ** expects number ** number'
 ---
 title: 'exponentiation of object by numbers'
 context: {a: {x: 10}, b: 1}
 template: {$eval: 'a ** b'}
-error: true
+error: 'InterpreterError: infix: ** expects number ** number'
 ---
 title: 'exponentiation of object by null'
 context: {a: {x: 10}, b: null}
 template: {$eval: 'a ** b'}
-error: true
+error: 'InterpreterError: infix: ** expects number ** number'
 ---
 title: 'exponentiation of object by booleans'
 context: {a: {x: 10}, b: true}
 template: {$eval: 'a ** b'}
-error: true
+error: 'InterpreterError: infix: ** expects number ** number'
 ---
 title: 'exponentiation of object by objects'
 context: {a: {x: 10}, b: {x: 1}}
 template: {$eval: 'a ** b'}
-error: true
+error: 'InterpreterError: infix: ** expects number ** number'
 ---
 title: 'exponentiation of object by arrays'
 context: {a: {x: 10}, b: [1, 2]}
 template: {$eval: 'a ** b'}
-error: true
+error: 'InterpreterError: infix: ** expects number ** number'
 ---
 title: 'unary negation of object'
 context: {a: {x: 10}}
 template: {$eval: '-a'}
-error: true
+error: 'InterpreterError: unary - expects number'
 ---
 title: 'unary plus of object'
 context: {a: {x: 10}}
 template: {$eval: '+a'}
-error: true
+error: 'InterpreterError: unary + expects number'
 ---
 title: 'addition of array to strings'
 context: {a: [1, 2], b: 'a'}
 template: {$eval: 'a + b'}
-error: true
+error: 'InterpreterError: infix: + expects numbers/strings + numbers/strings'
 ---
 title: 'addition of array to numbers'
 context: {a: [1, 2], b: 1}
 template: {$eval: 'a + b'}
-error: true
+error: 'InterpreterError: infix: + expects numbers/strings + numbers/strings'
 ---
 title: 'addition of array to null'
 context: {a: [1, 2], b: null}
 template: {$eval: 'a + b'}
-error: true
+error: 'InterpreterError: infix: + expects numbers/strings + numbers/strings'
 ---
 title: 'addition of array to booleans'
 context: {a: [1, 2], b: true}
 template: {$eval: 'a + b'}
-error: true
+error: 'InterpreterError: infix: + expects numbers/strings + numbers/strings'
 ---
 title: 'addition of array to objects'
 context: {a: [1, 2], b: {x: 1}}
 template: {$eval: 'a + b'}
-error: true
+error: 'InterpreterError: infix: + expects numbers/strings + numbers/strings'
 ---
 title: 'addition of array to arrays'
 context: {a: [1, 2], b: [1, 2]}
 template: {$eval: 'a + b'}
-error: true
+error: 'InterpreterError: infix: + expects numbers/strings + numbers/strings'
 ---
 title: 'subtraction of array from strings'
 context: {a: [1, 2], b: 'b'}
 template: {$eval: 'a-b'}
-error: true
+error: 'InterpreterError: infix: - expects number - number'
 ---
 title: 'subtraction of array from numbers'
 context: {a: [1, 2], b: 1}
 template: {$eval: 'a - b'}
-error: true
+error: 'InterpreterError: infix: - expects number - number'
 ---
 title: 'subtraction of array from null'
 context: {a: [1, 2], b: null}
 template: {$eval: 'a - b'}
-error: true
+error: 'InterpreterError: infix: - expects number - number'
 ---
 title: 'subtraction of array from booleans'
 context: {a: [1, 2], b: true}
 template: {$eval: 'a - b'}
-error: true
+error: 'InterpreterError: infix: - expects number - number'
 ---
 title: 'subtraction of array from objects'
 context: {a: [1, 2], b: {x: 1}}
 template: {$eval: 'a - b'}
-error: true
+error: 'InterpreterError: infix: - expects number - number'
 ---
 title: 'subtraction of array from arrays'
 context: {a: [1, 2], b: [1, 2]}
 template: {$eval: 'a - b'}
-error: true
+error: 'InterpreterError: infix: - expects number - number'
 ---
 title: 'multiplication of array to strings'
 context: {a: [1, 2], b: 'b'}
 template: {$eval: 'a * b'}
-error: true
+error: 'InterpreterError: infix: * expects number * number'
 ---
 title: 'multiplication of array to numbers'
 context: {a: [1, 2], b: 1}
 template: {$eval: 'a * b'}
-error: true
+error: 'InterpreterError: infix: * expects number * number'
 ---
 title: 'multiplication of array to null'
 context: {a: [1, 2], b: null}
 template: {$eval: 'a * b'}
-error: true
+error: 'InterpreterError: infix: * expects number * number'
 ---
 title: 'multiplication of array to booleans'
 context: {a: [1, 2], b: true}
 template: {$eval: 'a * b'}
-error: true
+error: 'InterpreterError: infix: * expects number * number'
 ---
 title: 'multiplication of array to objects'
 context: {a: [1, 2], b: {x: 1}}
 template: {$eval: 'a * b'}
-error: true
+error: 'InterpreterError: infix: * expects number * number'
 ---
 title: 'multiplication of array to arrays'
 context: {a: [1, 2], b: [1, 2]}
-template: {$eval: 'a / b'}
-error: true
+template: {$eval: 'a * b'}
+error: 'InterpreterError: infix: * expects number * number'
 ---
 title: 'division of array by strings'
 context: {a: [1, 2], b: 'b'}
 template: {$eval: 'a / b'}
-error: true
+error: 'InterpreterError: infix: / expects number / number'
 ---
 title: 'division of array by numbers'
 context: {a: [1, 2], b: 1}
 template: {$eval: 'a / b'}
-error: true
+error: 'InterpreterError: infix: / expects number / number'
 ---
 title: 'division of array by null'
 context: {a: [1, 2], b: null}
 template: {$eval: 'a / b'}
-error: true
+error: 'InterpreterError: infix: / expects number / number'
 ---
 title: 'division of array by booleans'
 context: {a: [1, 2], b: true}
 template: {$eval: 'a / b'}
-error: true
+error: 'InterpreterError: infix: / expects number / number'
 ---
 title: 'division of array by objects'
 context: {a: [1, 2], b: {x: 1}}
 template: {$eval: 'a / b'}
-error: true
+error: 'InterpreterError: infix: / expects number / number'
 ---
 title: 'division of array by arrays'
 context: {a: [1, 2], b: [1, 2]}
 template: {$eval: 'a / b'}
-error: true
+error: 'InterpreterError: infix: / expects number / number'
 ---
 title: 'exponentiation of array by strings'
 context: {a: [1, 2], b: 'b'}
 template: {$eval: 'a ** b'}
-error: true
+error: 'InterpreterError: infix: ** expects number ** number'
 ---
 title: 'exponentiation of array by numbers'
 context: {a: [1, 2], b: 1}
 template: {$eval: 'a ** b'}
-error: true
+error: 'InterpreterError: infix: ** expects number ** number'
 ---
 title: 'exponentiation of array by null'
 context: {a: [1, 2], b: null}
 template: {$eval: 'a ** b'}
-error: true
+error: 'InterpreterError: infix: ** expects number ** number'
 ---
 title: 'exponentiation of array by booleans'
 context: {a: [1, 2], b: true}
 template: {$eval: 'a ** b'}
-error: true
+error: 'InterpreterError: infix: ** expects number ** number'
 ---
 title: 'exponentiation of array by objects'
 context: {a: [1, 2], b: {x: 1}}
 template: {$eval: 'a ** b'}
-error: true
+error: 'InterpreterError: infix: ** expects number ** number'
 ---
 title: 'exponentiation of array by arrays'
 context: {a: [1, 2], b: [1, 2]}
 template: {$eval: 'a ** b'}
-error: true
+error: 'InterpreterError: infix: ** expects number ** number'
 ---
 title: 'unary negation of array'
 context: {a: [1, 2]}
 template: {$eval: '-a'}
-error: true
+error: 'InterpreterError: unary - expects number'
 ---
 title: 'unary plus of array'
 context: {a: [1, 2]}
 template: {$eval: '+a'}
-error: true
+error: 'InterpreterError: unary + expects number'
 ################################################################################
 ---
 section: expression language - logic

--- a/specification.yml
+++ b/specification.yml
@@ -1248,7 +1248,7 @@ section: $eval
 title: $eval of $eval
 context: {}
 template: {$eval: {$eval: '"13"'}}
-error: true
+error: 'TemplateError: $eval must be given a string expression'
 ---
 title: $eval with undefined properties
 context: {}
@@ -1316,7 +1316,7 @@ result: 1
 title: min - TypeError
 context: {}
 template: {$eval: 'min("11")'}
-error: true
+error: 'BuiltinError: invalid arguments to builtin: min'
 ---
 title: min - no arguments in template
 context: {}
@@ -1326,7 +1326,7 @@ error: "TemplateError: $eval min doesn't get any arguments in template"
 title: min (7)
 context: {}
 template: {$eval: 'min()'}
-error: true
+error: 'BuiltinError: invalid arguments to builtin: min: expected at least 1 arguments'
 ---
 title: max (1)
 context: {key1: 1, key2: 2}
@@ -1361,12 +1361,12 @@ result: 5
 title: max - TypeError
 context: {}
 template: {$eval: 'max("12")'}
-error: true
+error: 'BuiltinError: invalid arguments to builtin: max'
 ---
 title: max (7)
 context: {}
 template: {$eval: 'max()'}
-error: true
+error: 'BuiltinError: invalid arguments to builtin: max: expected at least 1 arguments'
 ---
 title: sqrt (1)
 context: {key: 4}
@@ -1391,7 +1391,7 @@ result: 3.0
 title: sqrt - TypeError
 context: {}
 template: {$eval: 'sqrt("nine")'}
-error: true
+error: 'BuiltinError: invalid arguments to builtin: sqrt'
 ---
 title: ceil (1)
 context: {key: 1.1}
@@ -1436,7 +1436,7 @@ result: 1.0
 title: ceil - TypeError
 context: {}
 template: {$eval: 'ceil(true)'}
-error: true
+error: 'BuiltinError: invalid arguments to builtin: ceil'
 ---
 title: floor (1)
 context: {key: 1.1}
@@ -1481,7 +1481,7 @@ result: 1.0
 title: floor - TypeError
 context: {key: null}
 template: {$eval: 'floor(key)'}
-error: true
+error: 'BuiltinError: invalid arguments to builtin: floor'
 ---
 title: abs (1)
 context: {key: -1.1}
@@ -1586,7 +1586,7 @@ result: 1.0
 title: abs - TypeError
 context: {}
 template: {$eval: 'abs({})'}
-error: true
+error: 'BuiltinError: invalid arguments to builtin: abs'
 ---
 title: lowercase (1)
 context: {key: 'HEllo'}
@@ -1601,32 +1601,32 @@ result: 'hello'
 title: TypeError lowercase (1)
 context: {key: {}}
 template: {$eval: 'lowercase(key)'}
-error: true
+error: 'BuiltinError: invalid arguments to builtin: lowercase'
 ---
 title: TypeError lowercase (2)
 context: {}
 template: {$eval: 'lowercase({})'}
-error: true
+error: 'BuiltinError: invalid arguments to builtin: lowercase'
 ---
 title: TypeError lowercase (3)
 context: {key: []}
 template: {$eval: 'lowercase(key)'}
-error: true
+error: 'BuiltinError: invalid arguments to builtin: lowercase'
 ---
 title: TypeError lowercase (4)
 context: {}
 template: {$eval: 'lowercase([])'}
-error: true
+error: 'BuiltinError: invalid arguments to builtin: lowercase'
 ---
 title: TypeError lowercase (5)
 context: {key: 1}
 template: {$eval: 'lowercase(key)'}
-error: true
+error: 'BuiltinError: invalid arguments to builtin: lowercase'
 ---
 title: TypeError lowercase (6)
 context: {}
 template: {$eval: 'lowercase(1)'}
-error: true
+error: 'BuiltinError: invalid arguments to builtin: lowercase'
 ---
 title: uppercase (1)
 context: {key: 'HEllo'}
@@ -1641,32 +1641,32 @@ result: 'HELLO'
 title: TypeError uppercase (1)
 context: {key: {}}
 template: {$eval: 'uppercase(key)'}
-error: true
+error: 'BuiltinError: invalid arguments to builtin: uppercase'
 ---
 title: TypeError uppercase (2)
 context: {}
 template: {$eval: 'uppercase({})'}
-error: true
+error: 'BuiltinError: invalid arguments to builtin: uppercase'
 ---
 title: TypeError uppercase (3)
 context: {key: []}
 template: {$eval: 'uppercase(key)'}
-error: true
+error: 'BuiltinError: invalid arguments to builtin: uppercase'
 ---
 title: TypeError uppercase (4)
 context: {}
 template: {$eval: 'uppercase([])'}
-error: true
+error: 'BuiltinError: invalid arguments to builtin: uppercase'
 ---
 title: TypeError uppercase (5)
 context: {key: 1}
 template: {$eval: 'uppercase(key)'}
-error: true
+error: 'BuiltinError: invalid arguments to builtin: uppercase'
 ---
 title: TypeError uppercase (6)
 context: {}
 template: {$eval: 'uppercase(1)'}
-error: true
+error: 'BuiltinError: invalid arguments to builtin: uppercase'
 ---
 title: len (1)
 context: {key: [1,2,3]}
@@ -1696,22 +1696,22 @@ result: 3
 title: TypeError len (1)
 context: {key: {}}
 template: {$eval: 'len(key)'}
-error: true
+error: 'BuiltinError: invalid arguments to builtin: len'
 ---
 title: TypeError len (2)
 context: {}
 template: {$eval: 'len({})'}
-error: true
+error: 'BuiltinError: invalid arguments to builtin: len'
 ---
 title: TypeError len (3)
 context: {key: 1}
 template: {$eval: 'len(key)'}
-error: true
+error: 'BuiltinError: invalid arguments to builtin: len'
 ---
 title: TypeError len (4)
 context: {}
 template: {$eval: 'len(1)'}
-error: true
+error: 'BuiltinError: invalid arguments to builtin: len'
 ---
 title: str (1)
 context: {key: 1}
@@ -1871,7 +1871,7 @@ result:   '2017-01-02T01:00:00.123Z'
 title:    fromNow - TypeError
 context:  {}
 template: {$eval: fromNow(13)}
-error: true
+error: 'BuiltinError: invalid arguments to builtin: fromNow'
 ---
 title:    typeof str
 context:  {}
@@ -2230,7 +2230,7 @@ section: expression language - operator type errors
 title: 'addition of strings to numbers'
 context: {a: 'a', b: 1}
 template: {$eval: 'a + b'}
-error: true
+error: 'InterpreterError: infix: + expects numbers/strings + numbers/strings'
 ---
 title: 'addition of strings to null'
 context: {a: 'a', b: null}
@@ -5040,7 +5040,7 @@ error: 'InterpreterError: unknown context value hello'
 title: 'Infix + type error'
 context: {}
 template: {$eval: 'true + false'}
-error: 'InterpreterError: infix: + expects number/string + number/string'
+error: 'InterpreterError: infix: + expects numbers/strings + numbers/strings'
 ---
 title: 'Infix - type error'
 context: {}

--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -140,7 +140,7 @@ let testComparisonOperands = (operator, left, right) => {
 
 let testMathOperands = (operator, left, right) => {
   if (operator === '+' && !(isNumber(left) && isNumber(right) || isString(left) && isString(right))) {
-    throw expectationError('infix: +', 'number/string + number/string');
+    throw expectationError('infix: +', 'numbers/strings + numbers/strings');
   }
   if (['-', '*', '/', '**'].some(v => v === operator) && !(isNumber(left) && isNumber(right))) {
     throw expectationError(`infix: ${operator}`, `number ${operator} number`);

--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -257,7 +257,7 @@ infixRules['.'] = (left, token, ctx) => {
     }
     throw new InterpreterError(`object has no property "${key}"`);
   }
-  throw expectationError('infix: .', 'object . object');
+  throw expectationError('infix: .', 'objects');
 };
 
 infixRules['('] =  (left, token, ctx) => {

--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -257,7 +257,7 @@ infixRules['.'] = (left, token, ctx) => {
     }
     throw new InterpreterError(`object has no property "${key}"`);
   }
-  throw expectationError('infix: .', 'objects');
+  throw expectationError('infix: .', 'object . object');
 };
 
 infixRules['('] =  (left, token, ctx) => {


### PR DESCRIPTION
Enforced that error messages for arithmetic operations, builtins, and strings are the same. This PR adds about 200 error messages.

# Checklist

* [x] All tests pass for you on your machine for all implementations (all implementations must behave identically)
* [ ] New tests have been added for any new functionality or to prevent regressions of a bugfix
* [x] Added a short description of the change to `newsfragments/$issue.bugfix` (for fixes) or `.feature` (for new features) or `.doc` (for documentation-only changes)
