### PR TITLE
Part fix for #168: Add error messages for invalid array indexing operations

### DIFF
--- a/jsone/builtins.py
+++ b/jsone/builtins.py
@@ -1,4 +1,3 @@
-# pylint: max-line-length=240
 from __future__ import absolute_import, print_function, unicode_literals
 
 import math

--- a/jsone/interpreter.py
+++ b/jsone/interpreter.py
@@ -279,7 +279,7 @@ def accessProperty(value, a, b, is_interval):
                 raise InterpreterError('should only use integers to access arrays or strings')
 
     if not isinstance(value, dict):
-        raise infixExpectationError('[..]', 'object, array, or string')
+        raise InterpreterError('infix: "[..]" expects object, array, or string')
     if not isinstance(a, string):
         raise InterpreterError('object keys must be strings')
 

--- a/jsone/interpreter.py
+++ b/jsone/interpreter.py
@@ -274,12 +274,12 @@ def accessProperty(value, a, b, is_interval):
             try:
                 return value[a]
             except IndexError:
-                raise TemplateError('index out of bounds')
+                raise InterpreterError('index out of bounds')
             except TypeError:
                 raise InterpreterError('should only use integers to access arrays or strings')
 
     if not isinstance(value, dict):
-        raise infixExpectationError('[..]', 'object, array, or string')
+        raise InterpreterError('cannot access properties from non-objects')
     if not isinstance(a, string):
         raise InterpreterError('object keys must be strings')
 

--- a/jsone/interpreter.py
+++ b/jsone/interpreter.py
@@ -279,7 +279,7 @@ def accessProperty(value, a, b, is_interval):
                 raise InterpreterError('should only use integers to access arrays or strings')
 
     if not isinstance(value, dict):
-        raise InterpreterError('cannot access properties from non-objects')
+        raise infixExpectationError('[..]', 'object, array, or string')
     if not isinstance(a, string):
         raise InterpreterError('object keys must be strings')
 

--- a/jsone/newsfragments/168.bugfix
+++ b/jsone/newsfragments/168.bugfix
@@ -1,3 +1,5 @@
 ## Part fix for #168: Enforce all error messages match
 
 Made sure error messages for arithmetic operations, builtins, and strings are the same.
+
+Added error messages for array indexing.

--- a/specification.yml
+++ b/specification.yml
@@ -3869,7 +3869,7 @@ result: 3
 title: 'numeric, noninteger index'
 context: {key: [1,2,3,4,5]}
 template: {$eval: 'key[2.5]'}
-error: true
+error: 'InterpreterError: should only use integers to access arrays or strings'
 ---
 title: 'arithemtic with results'
 context: {key: [1,2,3,4,5]}
@@ -3879,12 +3879,12 @@ result: 15
 title: 'string index'
 context: {key: [1,2,3,4,5]}
 template: {$eval: 'key["a"]'}
-error: true
+error: 'InterpreterError: should only use integers to access arrays or strings'
 ---
 title: 'too-large index'
 context: {key: [1,2,3,4,5]}
 template: {$eval: 'key[999]'}
-error: true
+error: 'InterpreterError: index out of bounds'
 ---
 title: 'negative index'
 context: {key: [1,2,3,4,5]}
@@ -3924,37 +3924,37 @@ result: 15
 title: 'indexing number'
 context: {key: 123}
 template: {$eval: 'key[2]'}
-error: true
+error: 'InterpreterError: cannot access properties from non-objects'
 ---
 title: 'indexing null'
 context: {key: null}
 template: {$eval: 'key[2]'}
-error: true
+error: 'InterpreterError: cannot access properties from non-objects'
 ---
 title: 'indexing boolean'
 context: {key: true}
 template: {$eval: 'key[2]'}
-error: true
+error: 'InterpreterError: cannot access properties from non-objects'
 ---
 title: 'indexing object'
 context: {key: {x: 10}}
 template: {$eval: 'key[2]'}
-error: true
+error: 'InterpreterError: object keys must be strings'
 ---
 title: 'array length property is an error'
 context: {key: [1, 3, 5]}
 template: {$eval: 'key.length'}
-error: true
+error: 'InterpreterError: infix: . expects object . object'
 ---
 title: 'array length property is an error even by index'
 context: {key: [1, 3, 5]}
 template: {$eval: 'key["length"]'}
-error: true
+error: 'InterpreterError: should only use integers to access arrays or strings'
 ---
 title: 'other array attributes are not available'
 context: {key: [5, 3, 1]}
 template: {$eval: 'key.sort'}
-error: true
+error: 'InterpreterError: infix: . expects object . object'
 ################################################################################
 ---
 section: expression language - array slicing

--- a/specification.yml
+++ b/specification.yml
@@ -3924,17 +3924,17 @@ result: 15
 title: 'indexing number'
 context: {key: 123}
 template: {$eval: 'key[2]'}
-error: 'InterpreterError: cannot access properties from non-objects'
+error: 'InterpreterError: infix: "[..]" expects object, array, or string'
 ---
 title: 'indexing null'
 context: {key: null}
 template: {$eval: 'key[2]'}
-error: 'InterpreterError: cannot access properties from non-objects'
+error: 'InterpreterError: infix: "[..]" expects object, array, or string'
 ---
 title: 'indexing boolean'
 context: {key: true}
 template: {$eval: 'key[2]'}
-error: 'InterpreterError: cannot access properties from non-objects'
+error: 'InterpreterError: infix: "[..]" expects object, array, or string'
 ---
 title: 'indexing object'
 context: {key: {x: 10}}
@@ -3944,7 +3944,7 @@ error: 'InterpreterError: object keys must be strings'
 title: 'array length property is an error'
 context: {key: [1, 3, 5]}
 template: {$eval: 'key.length'}
-error: 'InterpreterError: infix: . expects object . object'
+error: 'InterpreterError: infix: . expects objects'
 ---
 title: 'array length property is an error even by index'
 context: {key: [1, 3, 5]}
@@ -3954,7 +3954,7 @@ error: 'InterpreterError: should only use integers to access arrays or strings'
 title: 'other array attributes are not available'
 context: {key: [5, 3, 1]}
 template: {$eval: 'key.sort'}
-error: 'InterpreterError: infix: . expects object . object'
+error: 'InterpreterError: infix: . expects objects'
 ################################################################################
 ---
 section: expression language - array slicing

--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -105,7 +105,7 @@ let accessProperty = (left, a, b, isInterval) => {
 
   // if we reach here it means we are accessing property value from object
   if (!isObject(left)) {
-    throw new InterpreterError('cannot access properties from non-objects');
+    throw new InterpreterError('infix: "[..]" expects object, array, or string');
   }
 
   if (!isString(a)) {

--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -257,7 +257,7 @@ infixRules['.'] = (left, token, ctx) => {
     }
     throw new InterpreterError(`object has no property "${key}"`);
   }
-  throw expectationError('infix: .', 'object . object');
+  throw expectationError('infix: .', 'objects');
 };
 
 infixRules['('] =  (left, token, ctx) => {

--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -257,7 +257,7 @@ infixRules['.'] = (left, token, ctx) => {
     }
     throw new InterpreterError(`object has no property "${key}"`);
   }
-  throw expectationError('infix: .', 'objects');
+  throw expectationError('infix: .', 'object . object');
 };
 
 infixRules['('] =  (left, token, ctx) => {


### PR DESCRIPTION
This PR adds error messages for invalid array indexing operations such as trying to index a boolean or null value. No new features or functionality was added.

# Checklist

Before submitting a pull request, please check the following:

* [x] All tests pass for you on your machine for all implementations (all implementations must behave identically)
* [ ] New tests have been added for any new functionality or to prevent regressions of a bugfix
* [x] Added a short description of the change to `newsfragments/$issue.bugfix` (for fixes) or `.feature` (for new features) or `.doc` (for documentation-only changes)
