### PR TITLE
fromNow: use now from current context (JS) #210 (WIP)

### DIFF
--- a/src/builtins.js
+++ b/src/builtins.js
@@ -21,12 +21,17 @@ let builtinError = (builtin) => new BuiltinError(`invalid arguments to ${builtin
 
 module.exports = (context) => {
   let builtins = {};
+  let currentContext = {}
+
   let define = (name, context, {
     argumentTests = [],
     minArgs = false,
     variadic = null,
     invoke,
-  }) => context[name] = (...args) => {
+  }) => context[name] = (context, args) => {
+
+    currentContext = context
+
     if (!variadic && args.length < argumentTests.length) {
       throw builtinError(`builtin: ${name}`, `${args.toString()}, too few arguments`);
     }
@@ -120,7 +125,9 @@ module.exports = (context) => {
   define('fromNow', builtins, {
     variadic: 'string',
     minArgs: 1,
-    invoke: (str, reference) => fromNow(str, reference || context.now),
+    invoke: (str, reference) => {
+    return  fromNow(str, reference || currentContext.now || context.now)
+    },
   });
 
   define('typeof', builtins, {

--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -261,8 +261,9 @@ infixRules['.'] = (left, token, ctx) => {
 };
 
 infixRules['('] =  (left, token, ctx) => {
+
   if (isFunction(left)) {
-    return left.apply(null, parseList(ctx, ',', ')'));
+    return left.apply(null , [ctx.context, parseList(ctx, ',', ')')]);
   }
   throw expectationError('infix: f(args)', 'f to be function');
 };


### PR DESCRIPTION
Partial fix for #210  - fromNow uses now from the current context (JS)

Need an input if I'm on the right track. PR solves an issue, but 2 tests fail now. 
