### PR TITLE
Don't try to cast unicode to bytes in str()

### DIFF
--- a/jsone/newsfragments/338.bugfix
+++ b/jsone/newsfragments/338.bugfix
@@ -1,0 +1,1 @@
+Strings containing unicode are now handled correctly by str() on Python 2.

--- a/jsone/shared.py
+++ b/jsone/shared.py
@@ -107,6 +107,8 @@ def to_str(v):
         return ','.join(to_str(e) for e in v)
     elif v is None:
         return 'null'
+    elif isinstance(v, string):
+        return v
     else:
         return str(v)
 

--- a/specification.yml
+++ b/specification.yml
@@ -1773,6 +1773,11 @@ context: {val: 24}
 template: {$eval: 'str(val)'}
 result: '24'
 ---
+title: str (unicode)
+context: {val: "let's make a ☃"}
+template: {$eval: 'str(val)'}
+result: "let's make a ☃"
+---
 title: str({})
 context: {}
 template: {$eval: 'str({})'}


### PR DESCRIPTION
This fixes an issue on Python 2 where json-e casually handles both bytes
and unicode strings.  The issue is not present on Python 3.

Fixes #338.

# Checklist

Before submitting a pull request, please check the following:

* [x] All tests pass for you on your machine for all implementations (all implementations must behave identically)
* [x] New tests have been added for any new functionality or to prevent regressions of a bugfix
* [x] Added a short description of the change to `newsfragments/$issue.bugfix` (for fixes) or `.feature` (for new features) or `.doc` (for documentation-only changes)
