### PR TITLE
354 fix constructor name

### DIFF
--- a/jsone/newsfragments/354.bugfix
+++ b/jsone/newsfragments/354.bugfix
@@ -1,0 +1,1 @@
+Fix error (constructor.name) when using with Webpack in production mode

--- a/src/AST.js
+++ b/src/AST.js
@@ -1,6 +1,7 @@
 class ASTNode {
     constructor(token) {
         this.token = token;
+        this.constructorName = 'ASTNode';
     }
 }
 
@@ -9,6 +10,7 @@ let Primitive = ASTNode;
 class BinOp extends ASTNode {
     constructor(token, left, right) {
         super(token);
+        this.constructorName = 'BinOp';
         this.left = left;
         this.right = right;
     }
@@ -17,6 +19,7 @@ class BinOp extends ASTNode {
 class UnaryOp extends ASTNode {
     constructor(token, expr) {
         super(token);
+        this.constructorName = 'UnaryOp';
         this.expr = expr;
     }
 }
@@ -24,6 +27,7 @@ class UnaryOp extends ASTNode {
 class FunctionCall extends ASTNode {
     constructor(token, name, args) {
         super(token);
+        this.constructorName = 'FunctionCall';
         this.name = name;
         this.args = args;
     }
@@ -32,12 +36,14 @@ class FunctionCall extends ASTNode {
 class ContextValue {
     constructor(token) {
         this.token = token;
+        this.constructorName = 'ContextValue';
     }
 }
 
 class List extends ASTNode {
     constructor(token, list) {
         super(token);
+        this.constructorName = 'List';
         this.list = list;
     }
 }
@@ -45,6 +51,7 @@ class List extends ASTNode {
 class ValueAccess extends ASTNode {
     constructor(token, arr, isInterval, left, right) {
         super(token);
+        this.constructorName = 'ValueAccess';
         this.isInterval = isInterval;
         this.arr = arr;
         this.left = left;
@@ -56,6 +63,7 @@ class ValueAccess extends ASTNode {
 class Object extends ASTNode {
     constructor(token, obj) {
         super(token);
+        this.constructorName = 'Object';
         this.obj = obj;
     }
 }

--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -9,7 +9,7 @@ class Interpreter {
     }
 
     visit(node) {
-        let funcName = "visit_" + node.constructor.name;
+        let funcName = "visit_" + node.constructorName;
         return this[funcName](node);
     }
 


### PR DESCRIPTION
When using Webpack in production mode, constructor's name are optimized away. This leads to a TypeError in `src/interpreter.js`'s `visit` function.
# Checklist

Before submitting a pull request, please check the following:

* [x] All tests pass for you on your machine for all implementations (all implementations must behave identically)
* [x] New tests have been added for any new functionality or to prevent regressions of a bugfix
* [x] Added a short description of the change to `newsfragments/$issue.bugfix` (for fixes) or `.feature` (for new features) or `.doc` (for documentation-only changes)
