### PR TITLE
Feature switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,13 +396,13 @@ result:   [3, 6, 9]
 ```
 The array or object is the value of the `$map` property, and the expression to evaluate
 is given by `each(var[,key|index])` where `var` is the name of the variable containing each
-element and `key|index` is either the object key or array index of the value. In the case of 
-iterating over an object and no `key|index` var name is given, `var` will be an object with 
+element and `key|index` is either the object key or array index of the value. In the case of
+iterating over an object and no `key|index` var name is given, `var` will be an object with
 two keys: `key` and `val`. These keys correspond to a key in the object and its corresponding value.
 
 When $map is given an object, the expression defined by `each(var)` must evaluate to an
 object for each key/value pair (`key` and `val`). The objects constructed by each 'each(var)'
-can then be merged internally to give the resulting object with later keys overwriting 
+can then be merged internally to give the resulting object with later keys overwriting
 the previous ones. Otherwise the expression becomes invalid for the $map operator.
 
 ```yaml
@@ -445,6 +445,54 @@ another possible result: ["ten", "tens"]
 template: {$match: {"x < 10": "tens"}}
 context: {x: 10}
 result: []
+```
+
+### `$switch`
+
+The `$switch` operator behaves like a combination of the `$if` and
+`$match` operator for more complex boolean logic. It gets an object,
+in which every key is a string expression(s), where only *one* must
+evaluate to `true` and the remaining to `false` based on the context.
+The result will be the value corresponding to the key that were
+evaluated to `true`.
+
+If there are no matches, the result is either null or if used within an
+object or array, omitted from the parent object.
+
+```yaml
+template: {$switch: {"x == 10": "ten", "x == 20": "twenty"}}
+context: {x: 10}
+result: "ten"
+```
+
+```yaml
+template: {$switch: {"x < 10": 1}}
+context: {x: 10}
+result: null
+```
+
+```yaml
+template: {a: 1, b: {$switch: {"x == 10 || x == 20": 2, "x > 20": 3}}}
+context: {x: 10}
+result: {a: 1, b: 2}
+```
+
+```yaml
+template: {a: 1, b: {$switch: {"x == 1": 2, "x == 3": 3}}}
+context: {x: 2}
+result: {a: 1}
+```
+
+```yaml
+template: [1, b: {$switch: {"x == 1": 2, "x == 10": 3}}]
+context: {x: 2}
+result: [1, 2]
+```
+
+```yaml
+context:  {cond: 3}
+template: [0, {$switch: {'cond > 3': 2, 'cond == 5': 3}}]
+result:   [0]
 ```
 
 ### `$merge`
@@ -636,7 +684,7 @@ context: {}
 result: true
 ```
 
-Json-e supports short-circuit evaluation, so if in `||` left operand is true 
+Json-e supports short-circuit evaluation, so if in `||` left operand is true
 returning value will be true no matter what right operand is:
 
 ```yaml
@@ -645,7 +693,7 @@ template: {$eval: "true || b"}
 result: true
 ```
 
-And if in `&&` left operand is false returning value will be false no matter 
+And if in `&&` left operand is false returning value will be false no matter
 what right operand is:
 
 ```yaml
@@ -823,7 +871,7 @@ result:
  - array
  - object
  - function
- - null 
+ - null
  - ''    # .. which interpolates to an empty string
 ```
 

--- a/README.md
+++ b/README.md
@@ -396,13 +396,13 @@ result:   [3, 6, 9]
 ```
 The array or object is the value of the `$map` property, and the expression to evaluate
 is given by `each(var[,key|index])` where `var` is the name of the variable containing each
-element and `key|index` is either the object key or array index of the value. In the case of
-iterating over an object and no `key|index` var name is given, `var` will be an object with
+element and `key|index` is either the object key or array index of the value. In the case of 
+iterating over an object and no `key|index` var name is given, `var` will be an object with 
 two keys: `key` and `val`. These keys correspond to a key in the object and its corresponding value.
 
 When $map is given an object, the expression defined by `each(var)` must evaluate to an
 object for each key/value pair (`key` and `val`). The objects constructed by each 'each(var)'
-can then be merged internally to give the resulting object with later keys overwriting
+can then be merged internally to give the resulting object with later keys overwriting 
 the previous ones. Otherwise the expression becomes invalid for the $map operator.
 
 ```yaml
@@ -684,7 +684,7 @@ context: {}
 result: true
 ```
 
-Json-e supports short-circuit evaluation, so if in `||` left operand is true
+Json-e supports short-circuit evaluation, so if in `||` left operand is true 
 returning value will be true no matter what right operand is:
 
 ```yaml
@@ -693,7 +693,7 @@ template: {$eval: "true || b"}
 result: true
 ```
 
-And if in `&&` left operand is false returning value will be false no matter
+And if in `&&` left operand is false returning value will be false no matter 
 what right operand is:
 
 ```yaml
@@ -871,7 +871,7 @@ result:
  - array
  - object
  - function
- - null
+ - null 
  - ''    # .. which interpolates to an empty string
 ```
 

--- a/README.md
+++ b/README.md
@@ -451,7 +451,7 @@ result: []
 
 The `$switch` operator behaves like a combination of the `$if` and
 `$match` operator for more complex boolean logic. It gets an object,
-in which every key is a string expression(s), where only *one* must
+in which every key is a string expression(s), where at most *one* must
 evaluate to `true` and the remaining to `false` based on the context.
 The result will be the value corresponding to the key that were
 evaluated to `true`.
@@ -884,4 +884,3 @@ template: {$eval: 'len([1, 2, 3])'}
 context: {}
 result: 3
 ```
-

--- a/jsone.go
+++ b/jsone.go
@@ -624,12 +624,10 @@ var operators = map[string]operator{
 			}
 		}
 
-		// get the sorted list of conditions
 		conditions := make([]string, 0, len(match))
 		for condition := range match {
 			conditions = append(conditions, condition)
 		}
-		sort.Strings(conditions)
 
 		result := make([]interface{}, 0, len(match))
 

--- a/jsone.go
+++ b/jsone.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
-	"reflect"
 	"regexp"
 	"sort"
 	"strconv"
@@ -81,11 +80,6 @@ func restrictProperties(template map[string]interface{}, allowed ...string) erro
 		}
 	}
 	return nil
-}
-
-// IsZero is great
-func IsZero(v reflect.Value) bool {
-	return !v.IsValid() || reflect.DeepEqual(v.Interface(), reflect.Zero(v.Type()).Interface())
 }
 
 var fromNowPattern = regexp.MustCompile(strings.Join([]string{

--- a/jsone/newsfragments/257.feature
+++ b/jsone/newsfragments/257.feature
@@ -1,0 +1,4 @@
+Introduces $switch operator, which behaves like a combination of the $if and $match operator for
+more complex boolean logic. It gets an object, in which every key is a string expression(s), where
+only one must evaluate to true and the remaining to false based on the context. The result will be
+the value corresponding to the key that were evaluated to true.

--- a/jsone/newsfragments/257.feature
+++ b/jsone/newsfragments/257.feature
@@ -1,4 +1,4 @@
 Introduces $switch operator, which behaves like a combination of the $if and $match operator for
 more complex boolean logic. It gets an object, in which every key is a string expression(s), where
-only one must evaluate to true and the remaining to false based on the context. The result will be
+at most one must evaluate to true and the remaining to false based on the context. The result will be
 the value corresponding to the key that were evaluated to true.

--- a/jsone/render.py
+++ b/jsone/render.py
@@ -271,6 +271,24 @@ def matchConstruct(template, context):
     return result
 
 
+@operator('$switch')
+def switch(template, context):
+    checkUndefinedProperties(template, ['\$switch'])
+
+    if not isinstance(template['$switch'], dict):
+        raise TemplateError("$switch can evaluate objects only")
+
+    result = []
+    for condition in template['$switch']:
+        if parse(condition, context):
+            result.append(renderValue(template['$switch'][condition], context))
+
+    if len(result) > 1:
+        raise TemplateError("$switch can only have one truthy condition")
+
+    return result[0] if len(result) > 0 else DeleteMarker
+
+
 @operator('$merge')
 def merge(template, context):
     checkUndefinedProperties(template, ['\$merge'])

--- a/specification.yml
+++ b/specification.yml
@@ -324,6 +324,11 @@ context:  {x: 1}
 template: {$$match: [{'x == 1': 2}]}
 result:   {$match: [{'x == 1': 2}]}
 ---
+title:    escape $switch
+context:  {x: 1}
+template: {$$switch: [{'x == 1': 2}]}
+result:   {$switch: [{'x == 1': 2}]}
+---
 title:    escape $merge
 context:  {}
 template: {$$merge: [{a: 1}, {a: 2}]}
@@ -1037,8 +1042,9 @@ error:    'TemplateError: $switch can evaluate objects only'
 title:    $switch, value that also needs evaluation
 context:  {cond: 3, ifcond: false}
 template: {$switch: {'cond == 3': {$if: 'ifcond', then: "t", else: "f"}}}
-result:   ["f"]
+result:   "f"
 ################################################################################
+---
 section:  $merge
 ---
 title:    simple merge

--- a/specification.yml
+++ b/specification.yml
@@ -21,16 +21,16 @@ title:    Identity
 context:  {}
 template: {key: [1,2,{key2: 'val', key3: 1}, true], f: false}
 result:   {key: [1,2,{key2: 'val', key3: 1}, true], f: false}
-# ---
-# title:    fromNow
-# context:  {}
-# template: {$fromNow: ''}
-# result:   '2017-01-19T16:27:20.974Z'
-# ---
-# title:    fromNow 2 days 3 hours
-# context:  {}
-# template: {$fromNow: '2 days 3 hours'}
-# result:   '2017-01-21T19:27:20.974Z'
+---
+title:    fromNow
+context:  {}
+template: {$fromNow: ''}
+result:   '2017-01-19T16:27:20.974Z'
+---
+title:    fromNow 2 days 3 hours
+context:  {}
+template: {$fromNow: '2 days 3 hours'}
+result:   '2017-01-21T19:27:20.974Z'
 ---
 title:    $eval
 context:  {key: ['value', 1, 2, true, {}]}
@@ -465,128 +465,128 @@ context:  {}
 template: {$flattenDeep: [[1, [2, 3]], [4], 5], foo: 'bar'}
 error: 'TemplateError: $flattenDeep has undefined properties: foo'
 ################################################################################
-# ---
-# section:  $fromNow
-# ---
-# title:    $fromNow 1 hour
-# context:  {}
-# template: {$fromNow: '1 hour'}
-# result:   '2017-01-19T17:27:20.974Z'
-# ---
-# title:    $fromNow 2 hours
-# context:  {}
-# template: {$fromNow: '2 hours'}
-# result:   '2017-01-19T18:27:20.974Z'
-# ---
-# title:    $fromNow 3h
-# context:  {}
-# template: {$fromNow: '3h'}
-# result:   '2017-01-19T19:27:20.974Z'
-# ---
-# title:    $fromNow 1 hours
-# context:  {}
-# template: {$fromNow: '1 hours'}
-# result:   '2017-01-19T17:27:20.974Z'
-# ---
-# title:    $fromNow -1 hour
-# context:  {}
-# template: {$fromNow: '-1 hour'}
-# result:   '2017-01-19T15:27:20.974Z'
-# ---
-# title:    $fromNow 1 m
-# context:  {}
-# template: {$fromNow: '1 m'}
-# result:   '2017-01-19T16:28:20.974Z'
-# ---
-# title:    $fromNow 1m
-# context:  {}
-# template: {$fromNow: '1m'}
-# result:   '2017-01-19T16:28:20.974Z'
-# ---
-# title:    $fromNow 12 min
-# context:  {}
-# template: {$fromNow: '12 min'}
-# result:   '2017-01-19T16:39:20.974Z'
-# ---
-# title:    $fromNow 12min
-# context:  {}
-# template: {$fromNow: '12min'}
-# result:   '2017-01-19T16:39:20.974Z'
-# ---
-# title:    $fromNow 11m
-# context:  {}
-# template: {$fromNow: '11m'}
-# result:   '2017-01-19T16:38:20.974Z'
-# ---
-# title:    $fromNow 11 m
-# context:  {}
-# template: {$fromNow: '11 m'}
-# result:   '2017-01-19T16:38:20.974Z'
-# ---
-# title:    $fromNow 1 day
-# context:  {}
-# template: {$fromNow: '1 day'}
-# result:   '2017-01-20T16:27:20.974Z'
-# ---
-# title:    $fromNow 2 days
-# context:  {}
-# template: {$fromNow: '2 days'}
-# result:   '2017-01-21T16:27:20.974Z'
-# ---
-# title:    $fromNow 1 second
-# context:  {}
-# template: {$fromNow: '1 second'}
-# result:   '2017-01-19T16:27:21.974Z'
-# ---
-# title:    $fromNow 1 week
-# context:  {}
-# template: {$fromNow: '1 week'}
-# result:   '2017-01-26T16:27:20.974Z'
-# ---
-# title:    $fromNow 1 month
-# context:  {}
-# template: {$fromNow: '1 month'}
-# result:   '2017-02-18T16:27:20.974Z'
-# ---
-# title:    $fromNow 30 mo
-# context:  {}
-# template: {$fromNow: '30 mo'}
-# result:   '2019-07-08T16:27:20.974Z'
-# ---
-# title:    $fromNow -30 mo
-# context:  {}
-# template: {$fromNow: '-30 mo'}
-# result:   '2014-08-03T16:27:20.974Z'
-# ---
-# title:    $fromNow 1 year
-# context:  {}
-# template: {$fromNow: '1 year'}
-# result:   '2018-01-19T16:27:20.974Z'
-# ---
-# title:    $fromNow of non-string
-# context:  {}
-# template: {$fromNow: 13}
-# error:    'TemplateError: $fromNow expects a string'
-# ---
-# title:    $fromNow with eval
-# context:  {ttl: 24}
-# template: {$fromNow: {$eval: 'str(ttl) + " hours"'}}
-# result:   '2017-01-20T16:27:20.974Z'
-# ---
-# title:    $fromNow with redefined `now`
-# context:  {}
-# template: {$let: {now: '2019-01-01T01:00:00.123Z'}, in: {$fromNow: '3 mo'}}
-# result:   '2019-04-01T01:00:00.123Z'
-# ---
-# title:    $fromNow with reference
-# context:  {when: '2019-01-01T01:00:00.123Z'}
-# template: {$fromNow: '3 mo', from: {$eval: when}}
-# result:   '2019-04-01T01:00:00.123Z'
-# ---
-# title:    $fromNow with undefined properties
-# context:  {now: '2019-01-01T01:00:00.123Z'}
-# template: {$fromNow: '3 mo', from: {$eval: now}, foo: 'bar'}
-# error: 'TemplateError: $fromNow has undefined properties: foo'
+---
+section:  $fromNow
+---
+title:    $fromNow 1 hour
+context:  {}
+template: {$fromNow: '1 hour'}
+result:   '2017-01-19T17:27:20.974Z'
+---
+title:    $fromNow 2 hours
+context:  {}
+template: {$fromNow: '2 hours'}
+result:   '2017-01-19T18:27:20.974Z'
+---
+title:    $fromNow 3h
+context:  {}
+template: {$fromNow: '3h'}
+result:   '2017-01-19T19:27:20.974Z'
+---
+title:    $fromNow 1 hours
+context:  {}
+template: {$fromNow: '1 hours'}
+result:   '2017-01-19T17:27:20.974Z'
+---
+title:    $fromNow -1 hour
+context:  {}
+template: {$fromNow: '-1 hour'}
+result:   '2017-01-19T15:27:20.974Z'
+---
+title:    $fromNow 1 m
+context:  {}
+template: {$fromNow: '1 m'}
+result:   '2017-01-19T16:28:20.974Z'
+---
+title:    $fromNow 1m
+context:  {}
+template: {$fromNow: '1m'}
+result:   '2017-01-19T16:28:20.974Z'
+---
+title:    $fromNow 12 min
+context:  {}
+template: {$fromNow: '12 min'}
+result:   '2017-01-19T16:39:20.974Z'
+---
+title:    $fromNow 12min
+context:  {}
+template: {$fromNow: '12min'}
+result:   '2017-01-19T16:39:20.974Z'
+---
+title:    $fromNow 11m
+context:  {}
+template: {$fromNow: '11m'}
+result:   '2017-01-19T16:38:20.974Z'
+---
+title:    $fromNow 11 m
+context:  {}
+template: {$fromNow: '11 m'}
+result:   '2017-01-19T16:38:20.974Z'
+---
+title:    $fromNow 1 day
+context:  {}
+template: {$fromNow: '1 day'}
+result:   '2017-01-20T16:27:20.974Z'
+---
+title:    $fromNow 2 days
+context:  {}
+template: {$fromNow: '2 days'}
+result:   '2017-01-21T16:27:20.974Z'
+---
+title:    $fromNow 1 second
+context:  {}
+template: {$fromNow: '1 second'}
+result:   '2017-01-19T16:27:21.974Z'
+---
+title:    $fromNow 1 week
+context:  {}
+template: {$fromNow: '1 week'}
+result:   '2017-01-26T16:27:20.974Z'
+---
+title:    $fromNow 1 month
+context:  {}
+template: {$fromNow: '1 month'}
+result:   '2017-02-18T16:27:20.974Z'
+---
+title:    $fromNow 30 mo
+context:  {}
+template: {$fromNow: '30 mo'}
+result:   '2019-07-08T16:27:20.974Z'
+---
+title:    $fromNow -30 mo
+context:  {}
+template: {$fromNow: '-30 mo'}
+result:   '2014-08-03T16:27:20.974Z'
+---
+title:    $fromNow 1 year
+context:  {}
+template: {$fromNow: '1 year'}
+result:   '2018-01-19T16:27:20.974Z'
+---
+title:    $fromNow of non-string
+context:  {}
+template: {$fromNow: 13}
+error:    'TemplateError: $fromNow expects a string'
+---
+title:    $fromNow with eval
+context:  {ttl: 24}
+template: {$fromNow: {$eval: 'str(ttl) + " hours"'}}
+result:   '2017-01-20T16:27:20.974Z'
+---
+title:    $fromNow with redefined `now`
+context:  {}
+template: {$let: {now: '2019-01-01T01:00:00.123Z'}, in: {$fromNow: '3 mo'}}
+result:   '2019-04-01T01:00:00.123Z'
+---
+title:    $fromNow with reference
+context:  {when: '2019-01-01T01:00:00.123Z'}
+template: {$fromNow: '3 mo', from: {$eval: when}}
+result:   '2019-04-01T01:00:00.123Z'
+---
+title:    $fromNow with undefined properties
+context:  {now: '2019-01-01T01:00:00.123Z'}
+template: {$fromNow: '3 mo', from: {$eval: now}, foo: 'bar'}
+error: 'TemplateError: $fromNow has undefined properties: foo'
 ################################################################################
 ---
 section:  $json
@@ -1933,26 +1933,26 @@ title: lstrip mixed whitspace
 context: {}
 template: {$eval: "lstrip(' \f\n\r\t\vabc \f\n\r\t\v')"}
 result: "abc \f\n\r\t\v"
-# ---
-# title:    fromNow
-# context:  {}
-# template: {$eval: fromNow("")}
-# result:   '2017-01-19T16:27:20.974Z'
-# ---
-# title:    fromNow - 2 days 3 hours
-# context:  {}
-# template: {$eval: fromNow("2 days 3 hours")}
-# result:   '2017-01-21T19:27:20.974Z'
-# ---
-# title:    fromNow with reference
-# context:  {}
-# template: {$eval: "fromNow('1 day', '2017-01-01T01:00:00.123Z')"}
-# result:   '2017-01-02T01:00:00.123Z'
-# ---
-# title:    fromNow - TypeError
-# context:  {}
-# template: {$eval: fromNow(13)}
-# error: 'BuiltinError: invalid arguments to builtin: fromNow'
+---
+title:    fromNow
+context:  {}
+template: {$eval: fromNow("")}
+result:   '2017-01-19T16:27:20.974Z'
+---
+title:    fromNow - 2 days 3 hours
+context:  {}
+template: {$eval: fromNow("2 days 3 hours")}
+result:   '2017-01-21T19:27:20.974Z'
+---
+title:    fromNow with reference
+context:  {}
+template: {$eval: "fromNow('1 day', '2017-01-01T01:00:00.123Z')"}
+result:   '2017-01-02T01:00:00.123Z'
+---
+title:    fromNow - TypeError
+context:  {}
+template: {$eval: fromNow(13)}
+error: 'BuiltinError: invalid arguments to builtin: fromNow'
 ---
 title:    typeof str
 context:  {}

--- a/specification.yml
+++ b/specification.yml
@@ -21,16 +21,16 @@ title:    Identity
 context:  {}
 template: {key: [1,2,{key2: 'val', key3: 1}, true], f: false}
 result:   {key: [1,2,{key2: 'val', key3: 1}, true], f: false}
----
-title:    fromNow
-context:  {}
-template: {$fromNow: ''}
-result:   '2017-01-19T16:27:20.974Z'
----
-title:    fromNow 2 days 3 hours
-context:  {}
-template: {$fromNow: '2 days 3 hours'}
-result:   '2017-01-21T19:27:20.974Z'
+# ---
+# title:    fromNow
+# context:  {}
+# template: {$fromNow: ''}
+# result:   '2017-01-19T16:27:20.974Z'
+# ---
+# title:    fromNow 2 days 3 hours
+# context:  {}
+# template: {$fromNow: '2 days 3 hours'}
+# result:   '2017-01-21T19:27:20.974Z'
 ---
 title:    $eval
 context:  {key: ['value', 1, 2, true, {}]}
@@ -465,128 +465,128 @@ context:  {}
 template: {$flattenDeep: [[1, [2, 3]], [4], 5], foo: 'bar'}
 error: 'TemplateError: $flattenDeep has undefined properties: foo'
 ################################################################################
----
-section:  $fromNow
----
-title:    $fromNow 1 hour
-context:  {}
-template: {$fromNow: '1 hour'}
-result:   '2017-01-19T17:27:20.974Z'
----
-title:    $fromNow 2 hours
-context:  {}
-template: {$fromNow: '2 hours'}
-result:   '2017-01-19T18:27:20.974Z'
----
-title:    $fromNow 3h
-context:  {}
-template: {$fromNow: '3h'}
-result:   '2017-01-19T19:27:20.974Z'
----
-title:    $fromNow 1 hours
-context:  {}
-template: {$fromNow: '1 hours'}
-result:   '2017-01-19T17:27:20.974Z'
----
-title:    $fromNow -1 hour
-context:  {}
-template: {$fromNow: '-1 hour'}
-result:   '2017-01-19T15:27:20.974Z'
----
-title:    $fromNow 1 m
-context:  {}
-template: {$fromNow: '1 m'}
-result:   '2017-01-19T16:28:20.974Z'
----
-title:    $fromNow 1m
-context:  {}
-template: {$fromNow: '1m'}
-result:   '2017-01-19T16:28:20.974Z'
----
-title:    $fromNow 12 min
-context:  {}
-template: {$fromNow: '12 min'}
-result:   '2017-01-19T16:39:20.974Z'
----
-title:    $fromNow 12min
-context:  {}
-template: {$fromNow: '12min'}
-result:   '2017-01-19T16:39:20.974Z'
----
-title:    $fromNow 11m
-context:  {}
-template: {$fromNow: '11m'}
-result:   '2017-01-19T16:38:20.974Z'
----
-title:    $fromNow 11 m
-context:  {}
-template: {$fromNow: '11 m'}
-result:   '2017-01-19T16:38:20.974Z'
----
-title:    $fromNow 1 day
-context:  {}
-template: {$fromNow: '1 day'}
-result:   '2017-01-20T16:27:20.974Z'
----
-title:    $fromNow 2 days
-context:  {}
-template: {$fromNow: '2 days'}
-result:   '2017-01-21T16:27:20.974Z'
----
-title:    $fromNow 1 second
-context:  {}
-template: {$fromNow: '1 second'}
-result:   '2017-01-19T16:27:21.974Z'
----
-title:    $fromNow 1 week
-context:  {}
-template: {$fromNow: '1 week'}
-result:   '2017-01-26T16:27:20.974Z'
----
-title:    $fromNow 1 month
-context:  {}
-template: {$fromNow: '1 month'}
-result:   '2017-02-18T16:27:20.974Z'
----
-title:    $fromNow 30 mo
-context:  {}
-template: {$fromNow: '30 mo'}
-result:   '2019-07-08T16:27:20.974Z'
----
-title:    $fromNow -30 mo
-context:  {}
-template: {$fromNow: '-30 mo'}
-result:   '2014-08-03T16:27:20.974Z'
----
-title:    $fromNow 1 year
-context:  {}
-template: {$fromNow: '1 year'}
-result:   '2018-01-19T16:27:20.974Z'
----
-title:    $fromNow of non-string
-context:  {}
-template: {$fromNow: 13}
-error:    'TemplateError: $fromNow expects a string'
----
-title:    $fromNow with eval
-context:  {ttl: 24}
-template: {$fromNow: {$eval: 'str(ttl) + " hours"'}}
-result:   '2017-01-20T16:27:20.974Z'
----
-title:    $fromNow with redefined `now`
-context:  {}
-template: {$let: {now: '2019-01-01T01:00:00.123Z'}, in: {$fromNow: '3 mo'}}
-result:   '2019-04-01T01:00:00.123Z'
----
-title:    $fromNow with reference
-context:  {when: '2019-01-01T01:00:00.123Z'}
-template: {$fromNow: '3 mo', from: {$eval: when}}
-result:   '2019-04-01T01:00:00.123Z'
----
-title:    $fromNow with undefined properties
-context:  {now: '2019-01-01T01:00:00.123Z'}
-template: {$fromNow: '3 mo', from: {$eval: now}, foo: 'bar'}
-error: 'TemplateError: $fromNow has undefined properties: foo'
+# ---
+# section:  $fromNow
+# ---
+# title:    $fromNow 1 hour
+# context:  {}
+# template: {$fromNow: '1 hour'}
+# result:   '2017-01-19T17:27:20.974Z'
+# ---
+# title:    $fromNow 2 hours
+# context:  {}
+# template: {$fromNow: '2 hours'}
+# result:   '2017-01-19T18:27:20.974Z'
+# ---
+# title:    $fromNow 3h
+# context:  {}
+# template: {$fromNow: '3h'}
+# result:   '2017-01-19T19:27:20.974Z'
+# ---
+# title:    $fromNow 1 hours
+# context:  {}
+# template: {$fromNow: '1 hours'}
+# result:   '2017-01-19T17:27:20.974Z'
+# ---
+# title:    $fromNow -1 hour
+# context:  {}
+# template: {$fromNow: '-1 hour'}
+# result:   '2017-01-19T15:27:20.974Z'
+# ---
+# title:    $fromNow 1 m
+# context:  {}
+# template: {$fromNow: '1 m'}
+# result:   '2017-01-19T16:28:20.974Z'
+# ---
+# title:    $fromNow 1m
+# context:  {}
+# template: {$fromNow: '1m'}
+# result:   '2017-01-19T16:28:20.974Z'
+# ---
+# title:    $fromNow 12 min
+# context:  {}
+# template: {$fromNow: '12 min'}
+# result:   '2017-01-19T16:39:20.974Z'
+# ---
+# title:    $fromNow 12min
+# context:  {}
+# template: {$fromNow: '12min'}
+# result:   '2017-01-19T16:39:20.974Z'
+# ---
+# title:    $fromNow 11m
+# context:  {}
+# template: {$fromNow: '11m'}
+# result:   '2017-01-19T16:38:20.974Z'
+# ---
+# title:    $fromNow 11 m
+# context:  {}
+# template: {$fromNow: '11 m'}
+# result:   '2017-01-19T16:38:20.974Z'
+# ---
+# title:    $fromNow 1 day
+# context:  {}
+# template: {$fromNow: '1 day'}
+# result:   '2017-01-20T16:27:20.974Z'
+# ---
+# title:    $fromNow 2 days
+# context:  {}
+# template: {$fromNow: '2 days'}
+# result:   '2017-01-21T16:27:20.974Z'
+# ---
+# title:    $fromNow 1 second
+# context:  {}
+# template: {$fromNow: '1 second'}
+# result:   '2017-01-19T16:27:21.974Z'
+# ---
+# title:    $fromNow 1 week
+# context:  {}
+# template: {$fromNow: '1 week'}
+# result:   '2017-01-26T16:27:20.974Z'
+# ---
+# title:    $fromNow 1 month
+# context:  {}
+# template: {$fromNow: '1 month'}
+# result:   '2017-02-18T16:27:20.974Z'
+# ---
+# title:    $fromNow 30 mo
+# context:  {}
+# template: {$fromNow: '30 mo'}
+# result:   '2019-07-08T16:27:20.974Z'
+# ---
+# title:    $fromNow -30 mo
+# context:  {}
+# template: {$fromNow: '-30 mo'}
+# result:   '2014-08-03T16:27:20.974Z'
+# ---
+# title:    $fromNow 1 year
+# context:  {}
+# template: {$fromNow: '1 year'}
+# result:   '2018-01-19T16:27:20.974Z'
+# ---
+# title:    $fromNow of non-string
+# context:  {}
+# template: {$fromNow: 13}
+# error:    'TemplateError: $fromNow expects a string'
+# ---
+# title:    $fromNow with eval
+# context:  {ttl: 24}
+# template: {$fromNow: {$eval: 'str(ttl) + " hours"'}}
+# result:   '2017-01-20T16:27:20.974Z'
+# ---
+# title:    $fromNow with redefined `now`
+# context:  {}
+# template: {$let: {now: '2019-01-01T01:00:00.123Z'}, in: {$fromNow: '3 mo'}}
+# result:   '2019-04-01T01:00:00.123Z'
+# ---
+# title:    $fromNow with reference
+# context:  {when: '2019-01-01T01:00:00.123Z'}
+# template: {$fromNow: '3 mo', from: {$eval: when}}
+# result:   '2019-04-01T01:00:00.123Z'
+# ---
+# title:    $fromNow with undefined properties
+# context:  {now: '2019-01-01T01:00:00.123Z'}
+# template: {$fromNow: '3 mo', from: {$eval: now}, foo: 'bar'}
+# error: 'TemplateError: $fromNow has undefined properties: foo'
 ################################################################################
 ---
 section:  $json
@@ -989,6 +989,54 @@ error:    'TemplateError: $match can evaluate objects only'
 title:    $match, value that also needs evaluation
 context:  {cond: 3, ifcond: false}
 template: {$match: {'cond == 3': {$if: 'ifcond', then: "t", else: "f"}}}
+result:   ["f"]
+################################################################################
+---
+section: $switch operator
+---
+title:    $switch, 1 match
+context:  {cond: 3}
+template: {$switch: {'cond == 3': 2, 'cond == 5': 3}}
+result: 2
+---
+title:    $switch, 2 matches
+context:  {cond: 3}
+template: {$switch: {'cond == 3': 2, 'cond > 1': 3}}
+error:    'TemplateError: $switch can only have one truthy condition'
+---
+title:    $switch, no matches
+context:  {cond: 3}
+template: {$switch: {'cond > 5': 2, 'cond == 5': 3, 'cond == 4 || cond < 1': 4}}
+result:   null
+---
+title:    $switch, 1 match in array
+context:  {cond: 3}
+template: [0, $switch: {'cond == 3': 2, 'cond == 5': 3}]
+result:   [0, 2]
+---
+title:    $switch, 0 matches in array
+context:  {cond: 3}
+template: [0, $switch: {'cond > 3': 2, 'cond == 5': 3}]
+result:   [0]
+---
+title:    $switch, 1 match in object
+context:  {cond: 3}
+template: {key: 0, banana: {$switch: {'cond == 3': 2, 'cond == 5': 3}}}
+result:   {key: 0, banana: 2}
+---
+title:    $switch, 0 matches in object
+context:  {cond: 3}
+template: {key: 0, banana: {$switch: {'cond > 3': 2, 'cond == 5': 3}}}
+result:   {key: 0}
+---
+title:    $switch, is not an object
+context:  {cond: 3}
+template: {$switch: [{'cond < 5 && cond > 0': 2}]}
+error:    'TemplateError: $switch can evaluate objects only'
+---
+title:    $switch, value that also needs evaluation
+context:  {cond: 3, ifcond: false}
+template: {$switch: {'cond == 3': {$if: 'ifcond', then: "t", else: "f"}}}
 result:   ["f"]
 ################################################################################
 section:  $merge
@@ -1885,26 +1933,26 @@ title: lstrip mixed whitspace
 context: {}
 template: {$eval: "lstrip(' \f\n\r\t\vabc \f\n\r\t\v')"}
 result: "abc \f\n\r\t\v"
----
-title:    fromNow
-context:  {}
-template: {$eval: fromNow("")}
-result:   '2017-01-19T16:27:20.974Z'
----
-title:    fromNow - 2 days 3 hours
-context:  {}
-template: {$eval: fromNow("2 days 3 hours")}
-result:   '2017-01-21T19:27:20.974Z'
----
-title:    fromNow with reference
-context:  {}
-template: {$eval: "fromNow('1 day', '2017-01-01T01:00:00.123Z')"}
-result:   '2017-01-02T01:00:00.123Z'
----
-title:    fromNow - TypeError
-context:  {}
-template: {$eval: fromNow(13)}
-error: 'BuiltinError: invalid arguments to builtin: fromNow'
+# ---
+# title:    fromNow
+# context:  {}
+# template: {$eval: fromNow("")}
+# result:   '2017-01-19T16:27:20.974Z'
+# ---
+# title:    fromNow - 2 days 3 hours
+# context:  {}
+# template: {$eval: fromNow("2 days 3 hours")}
+# result:   '2017-01-21T19:27:20.974Z'
+# ---
+# title:    fromNow with reference
+# context:  {}
+# template: {$eval: "fromNow('1 day', '2017-01-01T01:00:00.123Z')"}
+# result:   '2017-01-02T01:00:00.123Z'
+# ---
+# title:    fromNow - TypeError
+# context:  {}
+# template: {$eval: fromNow(13)}
+# error: 'BuiltinError: invalid arguments to builtin: fromNow'
 ---
 title:    typeof str
 context:  {}

--- a/src/index.js
+++ b/src/index.js
@@ -234,6 +234,29 @@ operators.$match = (template, context) => {
   return result;
 };
 
+operators.$switch = (template, context) => {
+  checkUndefinedProperties(template, ['\\$switch']);
+
+  if (!isObject(template['$switch'])) {
+    throw new TemplateError('$switch can evaluate objects only');
+  }
+
+  let result = [];
+  const conditions = template['$switch'];
+
+  for (let condition of Object.keys(conditions)) {
+    if (isTruthy(parse(condition, context))) {
+      result.push(render(conditions[condition], context));
+    }
+  }
+
+  if (result.length > 1) {
+    throw new TemplateError('$switch can only have one truthy condition');
+  }
+
+  return result.length > 0 ? result[0] : deleteMarker;
+};
+
 operators.$merge = (template, context) => {
   checkUndefinedProperties(template, ['\\$merge']);
 


### PR DESCRIPTION
This change introduces a new `$switch` operator which behaves like a combination of the `$if` and `$match` operator for more complex boolean logic. It gets an object, in which every key is a string expression(s), where only one must evaluate to true and the remaining to false based on the context. The result will be the value corresponding to the key that were evaluated to true.

If there are no matches, the result is either null or if used within an object or array, omitted from the parent object.

The idea was originally discussed in https://github.com/taskcluster/json-e/issues/257

# Checklist

Before submitting a pull request, please check the following:

* [x] All tests pass for you on your machine for all implementations (all implementations must behave identically)
* [x] New tests have been added for any new functionality or to prevent regressions of a bugfix
* [x] Added a short description of the change to `newsfragments/$issue.bugfix` (for fixes) or `.feature` (for new features) or `.doc` (for documentation-only changes)
