### PR TITLE
Use raw strings for regexes

### DIFF
--- a/jsone/render.py
+++ b/jsone/render.py
@@ -115,7 +115,7 @@ def checkUndefinedProperties(template, allowed):
 
 @operator('$eval')
 def eval(template, context):
-    checkUndefinedProperties(template, ['\$eval'])
+    checkUndefinedProperties(template, [r'\$eval'])
     if not isinstance(template['$eval'], string):
         raise TemplateError("$eval must be given a string expression")
     return parse(template['$eval'], context)
@@ -123,7 +123,7 @@ def eval(template, context):
 
 @operator('$flatten')
 def flatten(template, context):
-    checkUndefinedProperties(template, ['\$flatten'])
+    checkUndefinedProperties(template, [r'\$flatten'])
     value = renderValue(template['$flatten'], context)
     if not isinstance(value, list):
         raise TemplateError('$flatten value must evaluate to an array')
@@ -140,7 +140,7 @@ def flatten(template, context):
 
 @operator('$flattenDeep')
 def flattenDeep(template, context):
-    checkUndefinedProperties(template, ['\$flattenDeep'])
+    checkUndefinedProperties(template, [r'\$flattenDeep'])
     value = renderValue(template['$flattenDeep'], context)
     if not isinstance(value, list):
         raise TemplateError('$flattenDeep value must evaluate to an array')
@@ -158,7 +158,7 @@ def flattenDeep(template, context):
 
 @operator('$fromNow')
 def fromNow(template, context):
-    checkUndefinedProperties(template, ['\$fromNow', 'from'])
+    checkUndefinedProperties(template, [r'\$fromNow', 'from'])
     offset = renderValue(template['$fromNow'], context)
     reference = renderValue(
         template['from'], context) if 'from' in template else context.get('now')
@@ -170,7 +170,7 @@ def fromNow(template, context):
 
 @operator('$if')
 def ifConstruct(template, context):
-    checkUndefinedProperties(template, ['\$if', 'then', 'else'])
+    checkUndefinedProperties(template, [r'\$if', 'then', 'else'])
     condition = parse(template['$if'], context)
     try:
         if condition:
@@ -184,14 +184,14 @@ def ifConstruct(template, context):
 
 @operator('$json')
 def jsonConstruct(template, context):
-    checkUndefinedProperties(template, ['\$json'])
+    checkUndefinedProperties(template, [r'\$json'])
     value = renderValue(template['$json'], context)
     return json.dumps(value, separators=(',', ':'), sort_keys=True, ensure_ascii=False)
 
 
 @operator('$let')
 def let(template, context):
-    checkUndefinedProperties(template, ['\$let', 'in'])
+    checkUndefinedProperties(template, [r'\$let', 'in'])
     if not isinstance(template['$let'], dict):
         raise TemplateError("$let value must be an object")
 
@@ -213,8 +213,8 @@ def let(template, context):
 
 @operator('$map')
 def map(template, context):
-    EACH_RE = 'each\([a-zA-Z_][a-zA-Z0-9_]*(,\s*([a-zA-Z_][a-zA-Z0-9_]*))?\)'
-    checkUndefinedProperties(template, ['\$map', EACH_RE])
+    EACH_RE = r'each\([a-zA-Z_][a-zA-Z0-9_]*(,\s*([a-zA-Z_][a-zA-Z0-9_]*))?\)'
+    checkUndefinedProperties(template, [r'\$map', EACH_RE])
     value = renderValue(template['$map'], context)
     if not isinstance(value, list) and not isinstance(value, dict):
         raise TemplateError("$map value must evaluate to an array or object")
@@ -258,7 +258,7 @@ def map(template, context):
 
 @operator('$match')
 def matchConstruct(template, context):
-    checkUndefinedProperties(template, ['\$match'])
+    checkUndefinedProperties(template, [r'\$match'])
 
     if not isinstance(template['$match'], dict):
         raise TemplateError("$match can evaluate objects only")
@@ -273,7 +273,7 @@ def matchConstruct(template, context):
 
 @operator('$switch')
 def switch(template, context):
-    checkUndefinedProperties(template, ['\$switch'])
+    checkUndefinedProperties(template, [r'\$switch'])
 
     if not isinstance(template['$switch'], dict):
         raise TemplateError("$switch can evaluate objects only")
@@ -291,7 +291,7 @@ def switch(template, context):
 
 @operator('$merge')
 def merge(template, context):
-    checkUndefinedProperties(template, ['\$merge'])
+    checkUndefinedProperties(template, [r'\$merge'])
     value = renderValue(template['$merge'], context)
     if not isinstance(value, list) or not all(isinstance(e, dict) for e in value):
         raise TemplateError(
@@ -304,7 +304,7 @@ def merge(template, context):
 
 @operator('$mergeDeep')
 def merge(template, context):
-    checkUndefinedProperties(template, ['\$mergeDeep'])
+    checkUndefinedProperties(template, [r'\$mergeDeep'])
     value = renderValue(template['$mergeDeep'], context)
     if not isinstance(value, list) or not all(isinstance(e, dict) for e in value):
         raise TemplateError(
@@ -329,7 +329,7 @@ def merge(template, context):
 
 @operator('$reverse')
 def reverse(template, context):
-    checkUndefinedProperties(template, ['\$reverse'])
+    checkUndefinedProperties(template, [r'\$reverse'])
     value = renderValue(template['$reverse'], context)
     if not isinstance(value, list):
         raise TemplateError("$reverse value must evaluate to an array of objects")
@@ -338,8 +338,8 @@ def reverse(template, context):
 
 @operator('$sort')
 def sort(template, context):
-    BY_RE = 'by\([a-zA-Z_][a-zA-Z0-9_]*\)'
-    checkUndefinedProperties(template, ['\$sort', BY_RE])
+    BY_RE = r'by\([a-zA-Z_][a-zA-Z0-9_]*\)'
+    checkUndefinedProperties(template, [r'\$sort', BY_RE])
     value = renderValue(template['$sort'], context)
     if not isinstance(value, list):
         raise TemplateError('$sorted values to be sorted must have the same type')

--- a/jsone/shared.py
+++ b/jsone/shared.py
@@ -35,13 +35,13 @@ class InterpreterError(JSONTemplateError):
 # Regular expression matching: X days Y hours Z minutes
 # todo: support hr, wk, yr
 FROMNOW_RE = re.compile(''.join([
-    '^(\s*(?P<years>\d+)\s*y(ears?)?)?',
-    '(\s*(?P<months>\d+)\s*mo(nths?)?)?',
-    '(\s*(?P<weeks>\d+)\s*w(eeks?)?)?',
-    '(\s*(?P<days>\d+)\s*d(ays?)?)?',
-    '(\s*(?P<hours>\d+)\s*h(ours?)?)?',
-    '(\s*(?P<minutes>\d+)\s*m(in(utes?)?)?)?\s*',
-    '(\s*(?P<seconds>\d+)\s*s(ec(onds?)?)?)?\s*$',
+    r'^(\s*(?P<years>\d+)\s*y(ears?)?)?',
+    r'(\s*(?P<months>\d+)\s*mo(nths?)?)?',
+    r'(\s*(?P<weeks>\d+)\s*w(eeks?)?)?',
+    r'(\s*(?P<days>\d+)\s*d(ays?)?)?',
+    r'(\s*(?P<hours>\d+)\s*h(ours?)?)?',
+    r'(\s*(?P<minutes>\d+)\s*m(in(utes?)?)?)?\s*',
+    r'(\s*(?P<seconds>\d+)\s*s(ec(onds?)?)?)?\s*$',
 ]))
 
 


### PR DESCRIPTION
This solves DeprecationWarnings about invalid escape sequences in
"regular" strings.

Fixes #361.
