### PR TITLE
New feature: `split`

### DIFF
--- a/README.md
+++ b/README.md
@@ -824,6 +824,7 @@ template:
   - {$eval: 'lstrip("  room  ")'}
   - {$eval: 'rstrip("  room  ")'}
   - {$eval: 'strip("  room  ")'}
+  - {$eval: 'split("left:right", ":")'}
 context: {}
 result:
   - "fools!"
@@ -832,6 +833,7 @@ result:
   - "room  "
   - "  room"
   - room
+  - [left, right]
 ```
 
 #### Context

--- a/jsone.go
+++ b/jsone.go
@@ -163,6 +163,44 @@ var builtin = map[string]interface{}{
 	"rstrip": i.WrapFunction(func(s string) string {
 		return strings.TrimRightFunc(s, unicode.IsSpace)
 	}),
+	"split": i.WrapFunction(func(v interface{}, d ...interface{}) (interface{}, error) {
+
+		// We use variadic because golang doesn't support optional parameters
+		if len(d) > 1 {
+			return "", fmt.Errorf("split(value, delimiter) takes at-most two arguments, but was given %d", len(d))
+		}
+
+		var reference interface{} = nil
+
+		if len(d) == 1 {
+			reference = d[0]
+			_, isNumber := reference.(float64)
+			_, isString := reference.(string)
+
+			if !isString && !isNumber {
+				return "", fmt.Errorf("split(value, delimeter) delimeter must be a string or a number")
+			}
+		}
+
+		switch val := v.(type) {
+		case string:
+			var delimeter string = ""
+
+			if reference != nil {
+				delimeter = fmt.Sprintf("%v", reference)
+			}
+			split := strings.Split(val, delimeter)
+			result := make([]interface{}, len(split))
+			for i, v := range split {
+				result[i] = v
+			}
+
+			return result, nil
+
+		default:
+			return "", fmt.Errorf("split(value, delimiter) only works on strings and numbers")
+		}
+	}),
 	"str": i.WrapFunction(func(v interface{}) (string, error) {
 		switch val := v.(type) {
 		case string:

--- a/jsone/builtins.py
+++ b/jsone/builtins.py
@@ -56,6 +56,9 @@ def build():
     def is_string(v):
         return isinstance(v, string)
 
+    def is_string_or_number(v):
+        return is_string(v) or is_number(v)
+
     def is_string_or_array(v):
         return isinstance(v, (string, list))
 
@@ -103,6 +106,13 @@ def build():
     @builtin('lstrip', argument_tests=[is_string])
     def lstrip(s):
         return s.lstrip()
+
+    @builtin('split', variadic=is_string_or_number, minArgs=1)
+    def split(s, d=''):
+        if not d and is_string(s):
+            return list(s)
+
+        return s.split(to_str(d))
 
     @builtin('fromNow', variadic=is_string, minArgs=1, needs_context=True)
     def fromNow_builtin(context, offset, reference=None):

--- a/jsone/newsfragments/368.feature
+++ b/jsone/newsfragments/368.feature
@@ -1,0 +1,2 @@
+Introduces `split` to built-in string functions enabling string splitting with a delimeter. 
+Input and delimeter can either be `string` or `number`.

--- a/jsone/newsfragments/368.feature
+++ b/jsone/newsfragments/368.feature
@@ -1,2 +1,2 @@
-Introduces `split` to built-in string functions enabling string splitting with a delimeter. 
-Input and delimeter can either be `string` or `number`.
+Introduces `split` to built-in string functions enabling string splitting with a delimiter. 
+Input and delimiter can either be `string` or `number`.

--- a/specification.yml
+++ b/specification.yml
@@ -1940,6 +1940,41 @@ context: {}
 template: {$eval: "lstrip(' \f\n\r\t\vabc \f\n\r\t\v')"}
 result: "abc \f\n\r\t\v"
 ---
+title: split string with delimiter
+context: {}
+template: {$eval: "split('left:right', ':')"}
+result: ['left', 'right']
+---
+title: split string without delimiter
+context: {}
+template: {$eval: "split('spellme', '')"}
+result: ['s', 'p', 'e', 'l', 'l', 'm', 'e']
+---
+title: split with empty string
+context: {}
+template: {$eval: "split('', ':')"}
+result: ['']
+---
+title: split string with no match
+context: {}
+template: {$eval: "split('no semicolon', ':')"}
+result: ['no semicolon']
+---
+title: split with number delimiter
+context: {}
+template: {$eval: "split('left1right', 1)"}
+result: ['left', 'right']
+---
+title: split error with object
+context: {}
+template: {$eval: "split({})"}
+error: 'BuiltinError: invalid arguments to builtin: split'
+---
+title: split error with array
+context: {}
+template: {$eval: "split([])"}
+error: 'BuiltinError: invalid arguments to builtin: split'
+---
 title:    fromNow
 context:  {}
 template: {$eval: fromNow("")}

--- a/src/builtins.js
+++ b/src/builtins.js
@@ -125,6 +125,12 @@ module.exports = (context) => {
     invoke: str => str.replace(/^\s+/, ''),
   });
 
+  define('split', builtins, {
+    minArgs: 1,
+    variadic: 'string|number',
+    invoke: (input, delimiter) => input.split(delimiter)
+  });
+
   // Miscellaneous
   define('fromNow', builtins, {
     variadic: 'string',


### PR DESCRIPTION
Introduces `split` to built in string functions enabling string splitting with a delimeter. Input and delimeter can either be `string` or `number`.

Discussed in #368 

# Checklist

Before submitting a pull request, please check the following:

* [x] All tests pass for you on your machine for all implementations (all implementations must behave identically)
* [x] New tests have been added for any new functionality or to prevent regressions of a bugfix
* [x] Added a short description of the change to `newsfragments/$issue.bugfix` (for fixes) or `.feature` (for new features) or `.doc` (for documentation-only changes)