### PR TITLE
New feature: `join`

### DIFF
--- a/README.md
+++ b/README.md
@@ -836,10 +836,10 @@ result:
 
 #### Arrays
 
-Joins arrays of strings and numbers (including mixed types) into a string using a separator, which can also be either string or number.
-
 ```yaml
 template:
+  # Joins arrays of strings and numbers (including mixed types) into a string using a separator, 
+  # which can also be either string or number.
   - {$eval: 'join(["carpe", "diem"], " ")'}
   - {$eval: 'join([1, 3], 2)}'}
 context: {}

--- a/README.md
+++ b/README.md
@@ -836,7 +836,7 @@ result:
 
 #### Arrays
 
-Joins arrays of strings and numbers (including mixed types) into a string using a separator
+Joins arrays of strings and numbers (including mixed types) into a string using a separator, which can also be either string or number.
 
 ```yaml
 template:

--- a/README.md
+++ b/README.md
@@ -834,6 +834,18 @@ result:
   - room
 ```
 
+#### Arrays
+
+```yaml
+template:
+  - {$eval: 'join(["carpe", "diem"], " ")'}
+  - {$eval: 'join([1, 3], 2)}'}
+context: {}
+result:
+  - carpe diem
+  - 123
+```
+
 #### Context
 
 The `defined(varname)` built-in determines if the named variable is defined in the current context.

--- a/README.md
+++ b/README.md
@@ -836,6 +836,8 @@ result:
 
 #### Arrays
 
+Joins arrays of strings and numbers (including mixed types) into a string using a separator
+
 ```yaml
 template:
   - {$eval: 'join(["carpe", "diem"], " ")'}
@@ -843,7 +845,7 @@ template:
 context: {}
 result:
   - carpe diem
-  - 123
+  - "123"
 ```
 
 #### Context

--- a/jsone.go
+++ b/jsone.go
@@ -210,6 +210,50 @@ var builtin = map[string]interface{}{
 		}
 		return 0, fmt.Errorf("len(value) only works on arrays and strings")
 	}),
+	"join": i.WrapFunction(func(v []interface{}, sep ...interface{}) (string, error) {
+		// We use variadic because golang doesn't support optional parameters
+		if len(sep) > 1 {
+			return "", fmt.Errorf("join(value, seperator) takes at-most two arguments, but was given %d", len(sep))
+		}
+
+		var reference interface{} = nil
+
+		if len(sep) == 1 {
+			reference = sep[0]
+			_, isNumber := reference.(float64)
+			_, isString := reference.(string)
+
+			if !isString && !isNumber {
+				return "", fmt.Errorf("join(value, seperator) seperator must be a string or a number")
+			}
+		}
+
+		var seperator string = ""
+
+		if reference != nil {
+			seperator = fmt.Sprintf("%v", reference)
+		}
+
+		valuesText := []string{}
+
+		// Ensure list entries are strings
+		for i := range v {
+			item := v[i]
+			var text string
+
+			switch item.(type) {
+			case string:
+				text = fmt.Sprintf("%v", item)
+			case float64:
+				text = fmt.Sprintf("%v", item)
+			default:
+				return "", fmt.Errorf("join(value, seperator) value must be a list of strings or numbers")
+			}
+			valuesText = append(valuesText, text)
+		}
+
+		return strings.Join(valuesText, seperator), nil
+	}),
 	"fromNow": i.WrapFunctionWithContext(func(context map[string]interface{}, offset string, from ...string) (string, error) {
 		// We use variadic because golang doesn't support optional parameters
 		if len(from) > 1 {

--- a/jsone/builtins.py
+++ b/jsone/builtins.py
@@ -114,7 +114,7 @@ def build():
     def join(list, separator):
         # convert potential numbers into strings
         string_list = [str(int) for int in list]
-        return str(seperator).join(string_list)
+        return str(separator).join(string_list)
 
     @builtin('fromNow', variadic=is_string, minArgs=1, needs_context=True)
     def fromNow_builtin(context, offset, reference=None):

--- a/jsone/builtins.py
+++ b/jsone/builtins.py
@@ -114,7 +114,7 @@ def build():
     def join(list, separator):
         # convert potential numbers into strings
         string_list = [str(int) for int in list]
-      
+
         return str(separator).join(string_list)
       
     @builtin('split', variadic=is_string_or_number, minArgs=1)

--- a/jsone/builtins.py
+++ b/jsone/builtins.py
@@ -116,7 +116,7 @@ def build():
         string_list = [str(int) for int in list]
 
         return str(separator).join(string_list)
-      
+
     @builtin('split', variadic=is_string_or_number, minArgs=1)
     def split(s, d=''):
         if not d and is_string(s):

--- a/jsone/builtins.py
+++ b/jsone/builtins.py
@@ -111,7 +111,7 @@ def build():
         return s.lstrip()
 
     @builtin('join', argument_tests=[is_array, is_string_or_number])
-    def lstrip(list, seperator):
+    def join(list, separator):
         # convert potential numbers into strings
         string_list = [str(int) for int in list]
         return str(seperator).join(string_list)

--- a/jsone/builtins.py
+++ b/jsone/builtins.py
@@ -56,6 +56,12 @@ def build():
     def is_string(v):
         return isinstance(v, string)
 
+    def is_string_or_number(v):
+        return is_string(v) or is_number(v)
+
+    def is_array(v):
+        return isinstance(v, list)
+
     def is_string_or_array(v):
         return isinstance(v, (string, list))
 
@@ -103,6 +109,12 @@ def build():
     @builtin('lstrip', argument_tests=[is_string])
     def lstrip(s):
         return s.lstrip()
+
+    @builtin('join', argument_tests=[is_array, is_string_or_number])
+    def lstrip(list, seperator):
+        # convert potential numbers into strings
+        string_list = [str(int) for int in list]
+        return str(seperator).join(string_list)
 
     @builtin('fromNow', variadic=is_string, minArgs=1, needs_context=True)
     def fromNow_builtin(context, offset, reference=None):

--- a/jsone/newsfragments/370.feature
+++ b/jsone/newsfragments/370.feature
@@ -1,2 +1,1 @@
-Introduces `join` to join lists with a seperator. list items and seperator can either be `string` 
-or `number`.
+Introduces join to the built-in functions to join lists with a seperator. list items and separator can either be string or number.

--- a/jsone/newsfragments/370.feature
+++ b/jsone/newsfragments/370.feature
@@ -1,0 +1,2 @@
+Introduces `join` to join lists with a seperator. list items and seperator can either be `string` 
+or `number`.

--- a/specification.yml
+++ b/specification.yml
@@ -1940,6 +1940,36 @@ context: {}
 template: {$eval: "lstrip(' \f\n\r\t\vabc \f\n\r\t\v')"}
 result: "abc \f\n\r\t\v"
 ---
+title: join with string separator
+context: {}
+template: {$eval: "join(['join', 'me'], ' ')"}
+result: "join me"
+---
+title: join with same
+context: {}
+template: {$eval: "join([',', ','], ',')"}
+result: ",,,"
+---
+title: join with number separator
+context: {}
+template: {$eval: "join([1, 3], 2)"}
+result: "123"
+---
+title: join with string
+context: {}
+template: {$eval: "join('cannot join string')"}
+error: "BuiltinError: invalid arguments to builtin: join"
+---
+title: join with object
+context: {}
+template: {$eval: "join({})"}
+error: "BuiltinError: invalid arguments to builtin: join"
+---
+title: join with boolean
+context: {}
+template: {$eval: "join(false)"}
+error: "BuiltinError: invalid arguments to builtin: join"
+---
 title:    fromNow
 context:  {}
 template: {$eval: fromNow("")}

--- a/specification.yml
+++ b/specification.yml
@@ -1955,7 +1955,7 @@ context: {}
 template: {$eval: "join([1, 3], 2)"}
 result: "123"
 ---
-title: join with strings separated with numbers
+title: join with strings separated with number
 context: {}
 template: {$eval: "join(['one', 'three'], 2)"}
 result: "one2three"

--- a/specification.yml
+++ b/specification.yml
@@ -1955,6 +1955,16 @@ context: {}
 template: {$eval: "join([1, 3], 2)"}
 result: "123"
 ---
+title: join with strings separated with numbers
+context: {}
+template: {$eval: "join(["one", "three"], 2)"}
+result: "one2three"
+---
+title: join with numbers separated with string
+context: {}
+template: {$eval: "join([1, 3], 'two')"}
+result: "1two3"
+---
 title: join with string
 context: {}
 template: {$eval: "join('cannot join string')"}

--- a/specification.yml
+++ b/specification.yml
@@ -1957,7 +1957,7 @@ result: "123"
 ---
 title: join with strings separated with numbers
 context: {}
-template: {$eval: "join(["one", "three"], 2)"}
+template: {$eval: "join(['one', 'three'], 2)"}
 result: "one2three"
 ---
 title: join with numbers separated with string

--- a/src/builtins.js
+++ b/src/builtins.js
@@ -124,7 +124,7 @@ module.exports = (context) => {
     argumentTests: ['string'],
     invoke: str => str.replace(/^\s+/, ''),
   });
-  
+
   define('split', builtins, {
     minArgs: 1,
     variadic: 'string|number',
@@ -135,7 +135,7 @@ module.exports = (context) => {
     argumentTests: ['array', 'string|number'],
     invoke: (list, separator) => list.join(separator) 
   });
-    
+
   // Miscellaneous
   define('fromNow', builtins, {
     variadic: 'string',

--- a/src/builtins.js
+++ b/src/builtins.js
@@ -125,6 +125,11 @@ module.exports = (context) => {
     invoke: str => str.replace(/^\s+/, ''),
   });
 
+  define('join', builtins, {
+    argumentTests: ['array', 'string|number'],
+    invoke: (list, separator) => list.join(separator) 
+  });
+
   // Miscellaneous
   define('fromNow', builtins, {
     variadic: 'string',


### PR DESCRIPTION
Introduces `join` to the built-in functions to join lists with a seperator. list items and separator can either be `string` or `number`.

Discussed in #370 & #368.

# Checklist

Before submitting a pull request, please check the following:

* [x] All tests pass for you on your machine for all implementations (all implementations must behave identically)
* [x] New tests have been added for any new functionality or to prevent regressions of a bugfix
* [x] Added a short description of the change to `newsfragments/$issue.bugfix` (for fixes) or `.feature` (for new features) or `.doc` (for documentation-only changes)
