### PR TITLE
start using GoModules for the Go implementation

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -93,9 +93,8 @@ tasks:
             - /bin/bash
             - '-c'
             - >-
-              mkdir -p /go/src/github.com/taskcluster/json-e &&
-              cd /go/src/github.com/taskcluster/json-e &&
-              git clone ${repo.git_url} . &&
+              git clone ${repo.git_url} repo &&
+              cd repo &&
               git config advice.detachedHead false &&
               git checkout ${repo.ref} &&
               go get -v -d -t ./... &&

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/taskcluster/json-e
+
+go 1.14
+
+require (
+	github.com/stretchr/testify v1.6.1
+	gopkg.in/yaml.v2 v2.3.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
+gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/jsone/newsfragments/go-mod.feature
+++ b/jsone/newsfragments/go-mod.feature
@@ -1,0 +1,1 @@
+The Go port now uses GoModules.  It should nonetheless remain compatible with earlier versions of Go.


### PR DESCRIPTION
This adds `go.mod` and `go.sum`, making this easier to develop without installing it deep in a GOPATH structure.  Since the code doesn't change, versions of Go that are unaware of modules should continue to work just fine.

# Checklist

Before submitting a pull request, please check the following:

* [x] All tests pass for you on your machine for all implementations (all implementations must behave identically)
* [x] New tests have been added for any new functionality or to prevent regressions of a bugfix
* [x] Added a short description of the change to `newsfragments/$issue.bugfix` (for fixes) or `.feature` (for new features) or `.doc` (for documentation-only changes)
