### PR TITLE
use tox for python testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ src/github.com
 
 #python env file
 env
+/.tox/

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -72,8 +72,8 @@ tasks:
               cd repo &&
               git config advice.detachedHead false &&
               git checkout ${repo.ref} &&
-              pip install --no-use-pep517 -e . &&
-              python setup.py test
+              pip install tox &&
+              tox -e py27
         - image: 'python:3.6'
           name: python:3.6 tests
           command:
@@ -85,8 +85,21 @@ tasks:
               cd repo &&
               git config advice.detachedHead false &&
               git checkout ${repo.ref} &&
-              pip install --no-use-pep517 -e . &&
-              python setup.py test
+              pip install tox &&
+              tox -e py36
+        - image: 'python:3.7'
+          name: python:3.7 tests
+          command:
+            - /bin/bash
+            - '--login'
+            - '-c'
+            - >-
+              git clone ${repo.git_url} repo &&
+              cd repo &&
+              git config advice.detachedHead false &&
+              git checkout ${repo.ref} &&
+              pip install tox &&
+              tox -e py37
         - image: 'golangci/golangci-lint'
           name: golang lint and tests
           command:

--- a/setup.py
+++ b/setup.py
@@ -22,19 +22,10 @@ setup(name='json-e',
     url='https://taskcluster.github.io/json-e/',
     author_email='dustin@mozilla.com',
     packages=['jsone'],
-    test_suite='nose.collector',
     license='MPL2',
     extras_require={
         'release': [
             'towncrier',
         ],
-    },
-    tests_require=[
-        "freezegun",
-        "hypothesis",
-        "nose",
-        "PyYAML",
-        "python-dateutil",
-        'pep8',
-    ]
+    }
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,19 @@
+# tox (https://tox.readthedocs.io/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py27, py36, py37
+
+[testenv]
+deps =
+    PyYAML
+    pep8
+    python-dateutil
+    nose
+    hypothesis
+    freezegun
+    nose
+commands =
+    nosetests {posargs}


### PR DESCRIPTION
Apparently `python setup.py test` is being deprecated and the warning recommends using tox..