### PR TITLE
Use valid JSON in tests

### DIFF
--- a/specification.yml
+++ b/specification.yml
@@ -4576,22 +4576,22 @@ template: {$eval: 'a != b'}
 result:   false
 ---
 title:    complex object equality, true
-context:  {a: {x: 1,'y': {e: {g: {1}}}}, b: {x: 1,'y': {e: {g: {1}}}}}
+context:  {a: {x: 1,'y': {e: {g: {one: 1}}}}, b: {x: 1,'y': {e: {g: {one: 1}}}}}
 template: {$eval: 'a == b'}
 result:   true
 ---
 title:    complex object equality, false
-context:  {a: {x: 1,'y': {e: {g: {1}}}}, b: {x: 1,'y': {e: {g: {2}}}}}
+context:  {a: {x: 1,'y': {e: {g: {one: 1}}}}, b: {x: 1,'y': {e: {g: {two: 2}}}}}
 template: {$eval: 'a == b'}
 result:   false
 ---
 title:    complex object in-equality, true
-context:  {a: {x: 1,'y': {e: {g: {1}}}}, b: {x: 1,'y': {e: {g: {2}}}}}
+context:  {a: {x: 1,'y': {e: {g: {one: 1}}}}, b: {x: 1,'y': {e: {g: {two: 2}}}}}
 template: {$eval: 'a != b'}
 result:   true
 ---
 title:    complex object in-equality, false
-context:  {a: {x: 1,'y': {e: {g: {1}}}}, b: {x: 1,'y': {e: {g: {1}}}}}
+context:  {a: {x: 1,'y': {e: {g: {one: 1}}}}, b: {x: 1,'y': {e: {g: {one: 1}}}}}
 template: {$eval: 'a != b'}
 result:   false
 ---


### PR DESCRIPTION
This updates the tests to use valid JSON data structures for the tests.  The issue was `{1}`, which at least in Python parses as `{1: None}`, and thus has a non-string as a key.  This isn't allowed in JSON.  [Other parsers](https://onlineyamltools.com/convert-yaml-to-json) seem to translate it `{"1": null}` which is at least valid JSON.  At any rate, we're not building a YAML interpreter here, so let's just use inputs that are valid.