### PR TITLE
Use the correct SyntaxError class in JavaScript implementation.

### DIFF
--- a/jsone/newsfragments/399.bugfix
+++ b/jsone/newsfragments/399.bugfix
@@ -1,0 +1,1 @@
+JS implementation now throws instances of the correct SyntaxError type

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ var {
    isTruthy
 } = require('./type-utils');
 var addBuiltins = require('./builtins');
-var {JSONTemplateError, TemplateError} = require('./error');
+var {JSONTemplateError, TemplateError, SyntaxError} = require('./error');
 
 let syntaxRuleError = (token) => {
     return new SyntaxError(`Found: ${token.value} token, expected one of: !=, &&, (, *, **, +, -, ., /, <, <=, ==, >, >=, [, in, ||`);

--- a/test/misc_test.js
+++ b/test/misc_test.js
@@ -25,4 +25,9 @@ suite('misc', function() {
   test('now builtin returns a string', function() {
     assume(typeof jsone({$eval: 'now'}, {})).eql(typeof 'string');
   });
+
+  test('syntax error has correct type', function() {
+    let jsoneSyntaxError = require('../src/error').SyntaxError;
+    assume(() => jsone({$eval: 'this is not valid'}, {})).throws(jsoneSyntaxError);
+  });
 });


### PR DESCRIPTION
Some errors were instances of [the runtime's native `SyntaxError` class](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SyntaxError) rather than [the one defined in error.js](https://github.com/taskcluster/json-e/blob/v4.3.0/src/error.js#L20-L26).

# Checklist

Before submitting a pull request, please check the following:

* [x] All tests pass for you on your machine for all implementations (all implementations must behave identically)
* [x] New tests have been added for any new functionality or to prevent regressions of a bugfix
* [x] Added a short description of the change to `newsfragments/$issue.bugfix` (for fixes) or `.feature` (for new features) or `.doc` (for documentation-only changes)