### PR TITLE
Remove isJSON util from JavaScript implementation.

### DIFF
--- a/src/builtins.js
+++ b/src/builtins.js
@@ -2,7 +2,7 @@ var {BuiltinError} = require('./error');
 var fromNow = require('./from-now');
 var {
   isString, isNumber, isBool,
-  isArray, isObject, isJSON,
+  isArray, isObject,
   isNull, isFunction,
 } = require('./type-utils');
 
@@ -12,7 +12,6 @@ let types = {
   boolean: isBool,
   array: isArray,
   object: isObject,
-  json: isJSON,
   null: isNull,
   function: isFunction,
 };

--- a/src/type-utils.js
+++ b/src/type-utils.js
@@ -7,29 +7,6 @@ let utils = {
   isArray:    expr => expr instanceof Array,
   isObject:   expr => expr instanceof Object && !(expr instanceof Array) && !(expr instanceof Function),
   isFunction: expr => expr instanceof Function,
-  isJSON:     expr => {
-    if (utils.isString(expr) || utils.isNumber(expr) || utils.isBool(expr) || expr === null) {
-      return true;
-    }
-
-    if (utils.isArray(expr)) {
-      return expr.every(v => utils.isJSON(v));
-    }
-
-    let result = true;
-    if (utils.isObject(expr)) {
-      for (let key of Object.keys(expr)) {
-        if (expr.hasOwnProperty(key)) {
-          result = result && utils.isJSON(expr[key]);
-          if (!result) {
-            break;
-          }
-        }
-      }
-      return result;
-    }
-    return false;
-  },
   isTruthy: expr => {
     return expr!== null && (
       utils.isArray(expr) && expr.length > 0 ||

--- a/src/type-utils.js
+++ b/src/type-utils.js
@@ -17,7 +17,7 @@ let utils = {
     }
 
     let result = true;
-    if (utils.isobject(expr)) {
+    if (utils.isObject(expr)) {
       for (let key of Object.keys(expr)) {
         if (expr.hasOwnProperty(key)) {
           result = result && utils.isJSON(expr[key]);

--- a/test/misc_test.js
+++ b/test/misc_test.js
@@ -30,16 +30,4 @@ suite('misc', function() {
     let jsoneSyntaxError = require('../src/error').SyntaxError;
     assume(() => jsone({$eval: 'this is not valid'}, {})).throws(jsoneSyntaxError);
   });
-
-  test('isJSON works', function() {
-    let isJSON = require('../src/type-utils').isJSON;
-    assume(isJSON('a')).eql(true);
-    assume(isJSON(1)).eql(true);
-    assume(isJSON(null)).eql(true);
-    assume(isJSON([])).eql(true);
-    assume(isJSON({})).eql(true);
-    assume(isJSON(['a', 1, null, [true, [], {}], {x: { y: ['z']}}])).eql(true);
-    assume(isJSON(() => {})).eql(false);
-    assume(isJSON(['a', 1, null, [true, [], {}], {x: { y: [Symbol('z')]}}])).eql(false);
-  });
 });

--- a/test/misc_test.js
+++ b/test/misc_test.js
@@ -30,4 +30,9 @@ suite('misc', function() {
     let jsoneSyntaxError = require('../src/error').SyntaxError;
     assume(() => jsone({$eval: 'this is not valid'}, {})).throws(jsoneSyntaxError);
   });
+
+  test('isJSON works', function() {
+    let isJSON = require('../src/type-utils').isJSON;
+    assume(isJSON({})).eql(true);
+  });
 });

--- a/test/misc_test.js
+++ b/test/misc_test.js
@@ -33,6 +33,13 @@ suite('misc', function() {
 
   test('isJSON works', function() {
     let isJSON = require('../src/type-utils').isJSON;
+    assume(isJSON('a')).eql(true);
+    assume(isJSON(1)).eql(true);
+    assume(isJSON(null)).eql(true);
+    assume(isJSON([])).eql(true);
     assume(isJSON({})).eql(true);
+    assume(isJSON(['a', 1, null, [true, [], {}], {x: { y: ['z']}}])).eql(true);
+    assume(isJSON(() => {})).eql(false);
+    assume(isJSON(['a', 1, null, [true, [], {}], {x: { y: [Symbol('z')]}}])).eql(false);
   });
 });


### PR DESCRIPTION
The `isJSON` util was calling a nonexistent function (due to a typo).

**UPDATE:** Since it's not actually used, `isJSON` has now been entirely removed.

# Checklist

Before submitting a pull request, please check the following:

* [x] All tests pass for you on your machine for all implementations (all implementations must behave identically)
* [x] New tests have been added for any new functionality or to prevent regressions of a bugfix
* [ ] Added a short description of the change to `newsfragments/$issue.bugfix` (for fixes) or `.feature` (for new features) or `.doc` (for documentation-only changes)