### PR TITLE
Give a clear error message when context is not an object

### DIFF
--- a/js/src/index.js
+++ b/js/src/index.js
@@ -475,6 +475,9 @@ let parseUntilTerminator = (source, terminator, context) => {
 };
 
 module.exports = (template, context = {}) => {
+  if (typeof context !== 'object') {
+    throw new TemplateError('context must be an object');
+  }
   let test = Object.keys(context).every(v => /^[a-zA-Z_][a-zA-Z0-9_]*$/.test(v));
   if (!test) {
     throw new TemplateError('top level keys of context must follow /[a-zA-Z_][a-zA-Z0-9_]*/');

--- a/js/test/misc_test.js
+++ b/js/test/misc_test.js
@@ -8,6 +8,10 @@ suite('misc', function() {
     assume(jsone({$eval: 'my_builtin(3, 4)'}, {my_builtin})).eql(5);
   });
 
+  test('non-object context is not allowed', function() {
+    assume(() => jsone({}, "I am not an object")).throws(/must be an object/);
+  });
+
   test('time doesn\'t change mid-evaluation (operator)', function() {
     let template = [...Array(1000).keys()].map(() => ({$fromNow: ''}));
     let result = new Set(jsone(template, {}));

--- a/py/jsone/__init__.py
+++ b/py/jsone/__init__.py
@@ -9,6 +9,8 @@ _context_re = re.compile(r'[a-zA-Z_][a-zA-Z0-9_]*$')
 
 
 def render(template, context):
+    if type(context) != dict:
+        raise TemplateError("context must be a dictionary")
     if not all(_context_re.match(c) for c in context):
         raise TemplateError('top level keys of context must follow '
                             '/[a-zA-Z_][a-zA-Z0-9_]*/')

--- a/py/jsone/newsfragments/408.bugfix
+++ b/py/jsone/newsfragments/408.bugfix
@@ -1,0 +1,1 @@
+All implementations now enforce that context is an object.  This was always the intent, but the JS and Python implementations' validation was not particularly thorough.

--- a/py/test/test_misc.py
+++ b/py/test/test_misc.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 import math
 import datetime
-from nose.tools import eq_
+from nose.tools import eq_, assert_raises
 from jsone.shared import string, stringDate
 from jsone import render, JSONTemplateError
 
@@ -11,6 +11,9 @@ def test_custom_builtin():
     def my_builtin(x, y):
         return math.sqrt(x ** 2 + y ** 2)
     eq_(render({'$eval': 'my_builtin(3, 4)'}, {'my_builtin': my_builtin}), 5)
+
+def test_non_object_context():
+    assert_raises(JSONTemplateError, lambda: render({}, "abc"))
 
 def test_same_time_within_evaluation_operator():
     template = [{'$fromNow': ''} for _ in range(1000)]


### PR DESCRIPTION
This was never allowed, but the loose type checking in Python and JS
would have allowed some non-objects to be passed.

I believe this is not actually a breaking change, as this never worked in any language.  Before this PR:
```
lamport ~/p/json-e/py [main] $ python
Python 3.6.9 (default, Jan 26 2021, 15:33:00) 
[GCC 8.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import jsone
>>> jsone.render({}, "abcd")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/dustin/p/json-e/py/jsone/__init__.py", line 17, in render
    full_context.update(context)
ValueError: dictionary update sequence element #0 has length 1; 2 is required
>>> 
```
(because `update` expects either a dictionary or a sequence of 2-tuples, and instead got a sequence of 1-character strings)
```
lamport ~/p/json-e/js [main] $ node
Welcome to Node.js v15.9.0.
Type ".help" for more information.
> require('./src')({}, "abc");
Uncaught TemplateError: top level keys of context must follow /[a-zA-Z_][a-zA-Z0-9_]*/
    at module.exports (/home/dustin/p/json-e/js/src/index.js:480:11) {
  location: []
}
> 
```
(because `Object.keys("abc")` is `[0, 1, 2]`)

# Checklist

Before submitting a pull request, please check the following:

* [x] All tests pass for you on your machine for all implementations (all implementations must behave identically)
* [x] New tests have been added for any new functionality or to prevent regressions of a bugfix
* [x] Added a short description of the change to `newsfragments/$issue.bugfix` (for fixes) or `.feature` (for new features) or `.doc` (for documentation-only changes)
