### PR TITLE
Hide {} in error message from formatting machinery

### DIFF
--- a/rs/src/render.rs
+++ b/rs/src/render.rs
@@ -99,7 +99,9 @@ fn interpolate(mut source: &str, context: &Context) -> Result<String> {
                     let expr = source.get(offset + 2..).unwrap();
                     let (parsed, remainder) = interpreter::parse_partial(expr)?;
                     if remainder.get(0..1) != Some("}") {
-                        bail!("unterminated ${..} expression");
+                        // Hide '{' in this error message from the formatting machinery in bail macro
+                        let msg = "unterminated ${..} expression";
+                        bail!(msg);
                     }
                     let eval_result = interpreter::evaluate(&parsed, context)?;
 


### PR DESCRIPTION
I am considering supporting https://rust-lang.github.io/rfcs/2795-format-args-implicit-identifiers.html in a future version of the bail macro, which would make e.g. `{v}` interpolate a variable called `v`, matching the standard library macros:

```rust
bail!("error {v}");  // equivalent to bail!("error {}", v)
```

I've been looking into how widely used `{` is in bail macro error messages. It looks like this is one of only very few places where it's used intentionally as a `{` character, as opposed to someone writing `{v}` in the message and expecting it to interpolate the value of `v` (not realizing it doesn't do that currently). If we can write this one a different way, I think it would be reasonable to provide the interpolating behavior from RFC 2795 in the future.

# Checklist

* [ ] All tests pass for you on your machine for all implementations (all implementations must behave identically)
* [ ] New tests have been added for any new functionality or to prevent regressions of a bugfix
* [ ] Added a short description of the change to `newsfragments/$issue.bugfix` (for fixes) or `.feature` (for new features) or `.doc` (for documentation-only changes)
